### PR TITLE
BW-1313 Fixes Swagger not loading in Cromwell app

### DIFF
--- a/service/src/main/resources/static/swagger-ui.html
+++ b/service/src/main/resources/static/swagger-ui.html
@@ -10,7 +10,7 @@
     content="Composite Batch Analysis Service (C-BAS) SwaggerUI"
   />
   <title>Composite Batch Analysis Service (C-BAS) SwaggerUI</title>
-  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="./webjars/swagger-ui-dist/swagger-ui.css" >
 </head>
 
 <body>
@@ -18,8 +18,8 @@
 
 <div id="swagger-ui"></div>
 
-<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
-<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
+<script src="./webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+<script src="./webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
 <script>
     window.onload = () => {
       window.ui = SwaggerUIBundle({


### PR DESCRIPTION
CBAS Swagger not loads as expected both locally and in app setting:

<img src="https://user-images.githubusercontent.com/16748522/182717371-5e7ac44e-b9fb-47e2-b1a5-21f0e70bd772.png" width="70%" height="70%">

<img src="https://user-images.githubusercontent.com/16748522/182717387-1d4fe732-ba9b-41f4-991b-654a08a5da6d.png" width="70%" height="70%">

Closes https://broadworkbench.atlassian.net/browse/BW-1313