### PR TITLE
BW-1365: Make swagger calls relative to where swagger is being hosted

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -3,6 +3,9 @@ info:
   title: Terra Batch Analysis
   description: Manage batch analyses, workflows, and submissions in userspace
   version: 0.0.1
+servers:
+  - url: ./
+    description: Relative to the current swagger page
 paths:
   /status:
     get:


### PR DESCRIPTION
Adds a relative path to the APIs from swagger. Namely: relative to itself.

Example of swagger working in a deployed app instance:

![image](https://user-images.githubusercontent.com/13006282/183493728-b363332b-74d2-4b1d-b6a6-cc5432f4bfb2.png)
