### PR TITLE
BW-1341: Add POST run_sets API

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.11.RELEASE'
-    implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
+    implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.6'
     implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -211,6 +211,13 @@ components:
 
     ParameterDefinition:
       title: ParameterDefinition
+      properties:
+        definitionType:
+          type: string
+          description: Indicates that this is a literal value.
+          required: true
+          enum: [ literal, entity_lookup ]
+          example: entity_lookup
       oneOf:
         - $ref: '#/components/schemas/ParameterDefinitionEntityLookup'
         - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
@@ -225,14 +232,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/ParameterDefinition'
       properties:
-        definitionType:
-          type: string
-          description: Indicates that this is a literal value.
-          required: true
-          enum: [ 'literal' ]
-          example: literal
-        param_value:
-          required: true
+        parameter_value:
+          required: True
           oneOf:
             - type: string
             - type: integer
@@ -247,12 +248,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/ParameterDefinition'
       properties:
-        definitionType:
-          type: string
-          description: Indicates that this is an entity lookup.
-          required: true
-          enum: [ 'entity_lookup' ]
-          example: 'entity_lookup'
         entity_attribute:
           type: string
           description: The attribute name on the entity to use.

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -7,21 +7,6 @@ servers:
   - url: ./
     description: Relative to the current swagger page
 paths:
-  /pets:
-    patch:
-      tags: [ public ]
-      operationId: getPets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: '#/components/schemas/Cat'
-                - $ref: '#/components/schemas/Dog'
-      responses:
-        '200':
-          description: Updated
-
   /status:
     get:
       summary: Check status of the service
@@ -364,19 +349,3 @@ components:
         - SET_COMPLETE
         - SET_ERROR
       type: string
-
-    Dog:
-      type: object
-      properties:
-        bark:
-          type: boolean
-        breed:
-          type: string
-          enum: [Dingo, Husky, Retriever, Shepherd]
-    Cat:
-      type: object
-      properties:
-        hunts:
-          type: boolean
-        age:
-          type: integer

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -210,16 +210,17 @@ components:
       type: string
 
     # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can
-    # be used as parameter definitions. In addition it acts as the superclass for the various
-    # ParameterDefinitionX classes below. Because the codegen is imperfect, we have to explicitly
+    # be used as parameter definitions.
+    # In addition, in Java it acts as the superclass for the various
+    # ParameterDefinitionXYZ classes below. Because the codegen is imperfect, we have to explicitly
     # add 'allOf: ParameterDefinition' declarations to those classes to force the codegen to make
-    # them subclasses in java. In terms of how the swagger UI works, they seem to make no difference
+    # them subclasses... but in terms of how the swagger UI works, they seem to make no difference
     ParameterDefinition:
       title: ParameterDefinition
       properties:
         definitionType:
           type: string
-          description: Indicates that this is a literal value.
+          description: Indicates what type of parameter declaration this is.
           required: true
           enum: [ literal, entity_lookup ]
           example: entity_lookup

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -203,7 +203,8 @@ components:
     ParameterDefinition:
       title: ParameterDefinition
       properties:
-        definitionType:
+        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
+        "type":
           type: string
           description: Indicates what type of parameter declaration this is.
           required: true
@@ -213,7 +214,7 @@ components:
         - $ref: '#/components/schemas/ParameterDefinitionEntityLookup'
         - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
       discriminator:
-        propertyName: definitionType
+        propertyName: "type"
         mapping:
           literal: 'ParameterDefinitionLiteralValue'
           entity_lookup: 'ParameterDefinitionEntityLookup'

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -239,15 +239,8 @@ components:
         - $ref: '#/components/schemas/ParameterDefinition'
       properties:
         parameter_value:
+          description: The literal value to use. Can be any type, but must match the declared parameter_type.
           required: True
-          oneOf:
-            - type: string
-            - type: integer
-            - type: array
-            - type: boolean
-            - type: number
-            - type: object
-            - type: "null"
           example: hello world
     ParameterDefinitionEntityLookup:
       type: object

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -7,6 +7,21 @@ servers:
   - url: ./
     description: Relative to the current swagger page
 paths:
+  /pets:
+    patch:
+      tags: [ public ]
+      operationId: getPets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+      responses:
+        '200':
+          description: Updated
+
   /status:
     get:
       summary: Check status of the service
@@ -181,14 +196,8 @@ components:
         parameter_type:
           $ref: '#/components/schemas/ParameterValueType'
         source:
-          oneOf:
-            - $ref: '#/components/schemas/ParameterDefinitionEntityLookup'
-            - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
-          discriminator:
-            propertyName: definition_type
-            mapping:
-              literal: '#/components/schemas/ParameterDefinitionLiteralValue'
-              entity_lookup: '#/components/schemas/ParameterDefinitionEntityLookup'
+          $ref: '#/components/schemas/ParameterDefinition'
+
     ParameterValueType:
       title: ParameterValueType
       example: String
@@ -199,16 +208,31 @@ components:
         - Boolean
         - Float
       type: string
+
+    ParameterDefinition:
+      title: ParameterDefinition
+      oneOf:
+        - $ref: '#/components/schemas/ParameterDefinitionEntityLookup'
+        - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
+      discriminator:
+        propertyName: definitionType
+        mapping:
+          literal: 'ParameterDefinitionLiteralValue'
+          entity_lookup: 'ParameterDefinitionEntityLookup'
+
     ParameterDefinitionLiteralValue:
       type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterDefinition'
       properties:
-        definition_type:
+        definitionType:
           type: string
           description: Indicates that this is a literal value.
           required: true
           enum: [ 'literal' ]
           example: literal
         param_value:
+          required: true
           oneOf:
             - type: string
             - type: integer
@@ -220,8 +244,10 @@ components:
           example: hello world
     ParameterDefinitionEntityLookup:
       type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterDefinition'
       properties:
-        definition_type:
+        definitionType:
           type: string
           description: Indicates that this is an entity lookup.
           required: true
@@ -230,6 +256,7 @@ components:
         entity_attribute:
           type: string
           description: The attribute name on the entity to use.
+          required: true
           example: entity_field_foo_rating
     RunSetStateResponse:
       type: object
@@ -344,3 +371,18 @@ components:
         - SET_ERROR
       type: string
 
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -209,6 +209,11 @@ components:
         - Float
       type: string
 
+    # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can
+    # be used as parameter definitions. In addition it acts as the superclass for the various
+    # ParameterDefinitionX classes below. Because the codegen is imperfect, we have to explicitly
+    # add 'allOf: ParameterDefinition' declarations to those classes to force the codegen to make
+    # them subclasses in java. In terms of how the swagger UI works, they seem to make no difference
     ParameterDefinition:
       title: ParameterDefinition
       properties:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Terra Batch Analysis
-  description: Manage batch analyses, workflows, and submissions in userspace
+  description: Manage batch analyses, run configurations, and run sets in userspace
   version: 0.0.1
 servers:
   - url: ./
@@ -47,6 +47,22 @@ paths:
           $ref: '#/components/responses/UserError'
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/batch/v1/run_sets:
+    post:
+      tags: [ run_sets ]
+      summary: Combine an inputs definition with WDS entities to run a series of workflows
+      operationId: postRunSet
+      requestBody:
+        $ref: '#/components/requestBodies/PostRunSetRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/PostRunSetResponse'
+        '201':
+          $ref: '#/components/responses/PostRunSetResponse'
+        '400':
+          $ref: '#/components/responses/UserError'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/batch/v1/methods:
     get:
       summary: Lists known methods
@@ -75,6 +91,13 @@ components:
           schema:
             $ref: '#/components/schemas/RunRequest'
 
+    PostRunSetRequest:
+      description: Request body to run a set of workflows (by URL) with WDS inputs.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RunSetRequest'
+
   responses:
     PostRunResponse:
       description: Response from creating a new run
@@ -82,6 +105,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/RunStateResponse'
+    PostRunSetResponse:
+      description: Response from creating a new run set
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RunSetStateResponse'
     GetRunResponse:
       description: Details about runs
       content:
@@ -114,6 +143,109 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    RunSetRequest:
+      type: object
+      properties:
+        workflow_url:
+          type: string
+          description: URL to the workflow script to run
+          example: 'http://www.example.com/example.wdl'
+        workflow_param_definitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkflowParamDefinition'
+          description: Declarative input definition for combination with WDS entities
+        wds_entities:
+          $ref: '#/components/schemas/WdsEntitySet'
+
+    WdsEntitySet:
+      type: object
+      properties:
+        entity_type:
+          type: string
+          example: FOO
+        entity_ids:
+          type: array
+          items:
+            type: string
+          example:
+            - F0011111-1111-1111-1111-111111111111
+      description: The set of WDS entities to use when constructing the inputs.
+
+    WorkflowParamDefinition:
+      type: object
+      properties:
+        parameter_name:
+          type: string
+          example: workflow_input_foo_rating
+        parameter_type:
+          $ref: '#/components/schemas/ParameterValueType'
+        source:
+          oneOf:
+            - $ref: '#/components/schemas/ParameterDefinitionEntityLookup'
+            - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
+          discriminator:
+            propertyName: definition_type
+            mapping:
+              literal: '#/components/schemas/ParameterDefinitionLiteralValue'
+              entity_lookup: '#/components/schemas/ParameterDefinitionEntityLookup'
+    ParameterValueType:
+      title: ParameterValueType
+      example: String
+      description: What type of value this parameter expects
+      enum:
+        - String
+        - Int
+        - Boolean
+        - Float
+      type: string
+    ParameterDefinitionLiteralValue:
+      type: object
+      properties:
+        definition_type:
+          type: string
+          description: Indicates that this is a literal value.
+          required: true
+          enum: [ 'literal' ]
+          example: literal
+        param_value:
+          oneOf:
+            - type: string
+            - type: integer
+            - type: array
+            - type: boolean
+            - type: number
+            - type: object
+            - type: "null"
+          example: hello world
+    ParameterDefinitionEntityLookup:
+      type: object
+      properties:
+        definition_type:
+          type: string
+          description: Indicates that this is an entity lookup.
+          required: true
+          enum: [ 'entity_lookup' ]
+          example: 'entity_lookup'
+        entity_attribute:
+          type: string
+          description: The attribute name on the entity to use.
+          example: entity_field_foo_rating
+    RunSetStateResponse:
+      type: object
+      required: [run_set_id]
+      properties:
+        run_set_id:
+          type:
+            string
+          example: 00000000-0000-0000-0000-000000000000
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunStateResponse'
+        state:
+          $ref: '#/components/schemas/RunSetState'
+
     RunRequest:
       type: object
       properties:
@@ -202,3 +334,13 @@ components:
         - CANCELED
         - CANCELING
       type: string
+    RunSetState:
+      title: RunSetState
+      example: RUNNING
+      enum:
+        - SET_UNKNOWN_STATE
+        - SET_RUNNING
+        - SET_COMPLETE
+        - SET_ERROR
+      type: string
+

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -1,0 +1,36 @@
+package bio.terra.cbas.controllers;
+
+import bio.terra.cbas.api.RunSetsApi;
+import bio.terra.cbas.config.CromwellServerConfiguration;
+import bio.terra.cbas.model.RunSetRequest;
+import bio.terra.cbas.model.RunSetState;
+import bio.terra.cbas.model.RunSetStateResponse;
+import bio.terra.cbas.model.RunState;
+import bio.terra.cbas.model.RunStateResponse;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class RunSetsApiController implements RunSetsApi {
+
+  private final CromwellServerConfiguration cromwellConfig;
+
+  @Autowired
+  public RunSetsApiController(CromwellServerConfiguration cromwellConfig) {
+    this.cromwellConfig = cromwellConfig;
+  }
+
+  @Override
+  public ResponseEntity<RunSetStateResponse> postRunSet(RunSetRequest request) {
+    return new ResponseEntity<>(
+        new RunSetStateResponse()
+            .runSetId(UUID.randomUUID().toString())
+            .addRunsItem(
+                new RunStateResponse().runId(UUID.randomUUID().toString()).state(RunState.RUNNING))
+            .state(RunSetState.RUNNING),
+        HttpStatus.OK);
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -25,7 +25,6 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<RunSetStateResponse> postRunSet(RunSetRequest request) {
-    log.info(request.toString());
     return new ResponseEntity<>(
         new RunSetStateResponse()
             .runSetId(UUID.randomUUID().toString())

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -25,6 +25,7 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<RunSetStateResponse> postRunSet(RunSetRequest request) {
+    log.info(request.toString());
     return new ResponseEntity<>(
         new RunSetStateResponse()
             .runSetId(UUID.randomUUID().toString())


### PR DESCRIPTION
## Notes:

- The OpenAPI definition has a little bit of circularity with `ParameterDefinition` declaring it must be `oneOf` its subtypes and its subtypes declaring that they must have `allOf` the `ParameterDefinition` fields. That's not an openapi requirement but it is required to make our specific codegen play nicely. It took a little juggling but we got there in the end.
- You can add `log.info(request.toString());` to the java handler class to see the objects that the codegen creates for us (that's how I produced the examples below). Because of the `oneOf` juggling mentioned above there's a tiny bit more nested than I'd ideally have hand-crafted... but hopefully not too bad, considering.
- In order to avoid breaking changes while the UI catches up, I haven't _removed_ the old `runs` API in this PR. We can do that in a follow up.

## Java Interpretation Examples:

Some examples of how the codegen'd java classes interpret requests

### Literal Value

#### JSON value submitted over the API:
```json
{
  "workflow_url": "http://www.example.com/example.wdl",
  "workflow_param_definitions": [
    {
      "parameter_name": "workflow_input_foo_rating",
      "parameter_type": "String",
      "source": {
        "definitionType": "literal",
        "entity_attribute": "hello world"
      }
    }
  ],
  "wds_entities": {
    "entity_type": "FOO",
    "entity_ids": [
      "F0011111-1111-1111-1111-111111111111"
    ]
  }
}
```

#### Java Interpretation:
```
class RunSetRequest {
    workflowUrl: http://www.example.com/example.wdl
    workflowParamDefinitions: [class WorkflowParamDefinition {
        parameterName: workflow_input_foo_rating
        parameterType: String
        source: class ParameterDefinitionLiteralValue {
            class ParameterDefinition {
                definitionType: literal
            }
            parameterValue: hello world
        }
    }]
    wdsEntities: class WdsEntitySet {
        entityType: FOO
        entityIds: [F0011111-1111-1111-1111-111111111111]
    }
}
```

### Entity Lookup

#### JSON value submitted over the API:
```json
{
  "workflow_url": "http://www.example.com/example.wdl",
  "workflow_param_definitions": [
    {
      "parameter_name": "workflow_input_foo_rating",
      "parameter_type": "String",
      "source": {
        "definitionType": "entity_lookup",
        "entity_attribute": "entity_field_foo_rating"
      }
    }
  ],
  "wds_entities": {
    "entity_type": "FOO",
    "entity_ids": [
      "F0011111-1111-1111-1111-111111111111"
    ]
  }
}
```

#### Java Interpretation:
```
class RunSetRequest {
    workflowUrl: http://www.example.com/example.wdl
    workflowParamDefinitions: [class WorkflowParamDefinition {
        parameterName: workflow_input_foo_rating
        parameterType: String
        source: class ParameterDefinitionEntityLookup {
            class ParameterDefinition {
                definitionType: entity_lookup
            }
            entityAttribute: entity_field_foo_rating
        }
    }]
    wdsEntities: class WdsEntitySet {
        entityType: FOO
        entityIds: [F0011111-1111-1111-1111-111111111111]
    }
}
```