### PR TITLE
WM-1473: Adds swagger definitions for optional types

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -156,7 +156,7 @@ components:
           type: string
           example: workflow_input_foo_rating
         input_type:
-          $ref: '#/components/schemas/ParameterValueType'
+          $ref: '#/components/schemas/ParameterTypeDefinition'
         source:
           $ref: '#/components/schemas/ParameterDefinition'
 
@@ -167,15 +167,34 @@ components:
           type: string
           example: workflow_output_foo_rating
         output_type:
-          $ref: '#/components/schemas/ParameterValueType'
+          $ref: '#/components/schemas/ParameterTypeDefinition'
         record_attribute:
           type: string
           description: The attribute name on the record to use.
           required: true
           example: record_field_foo_rating
 
-    ParameterValueType:
-      title: ParameterValueType
+    ParameterTypeDefinition:
+      title: ParameterTypeDefinition
+      properties:
+        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
+        "type":
+          type: string
+          description: Indicates what type of parameter type definition this is.
+          required: true
+          enum: [ primitive, optional ]
+          example: record_lookup
+      oneOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'
+        - $ref: '#/components/schemas/ParameterTypeDefinitionOptional'
+      discriminator:
+        propertyName: "type"
+        mapping:
+          primitive: 'ParameterTypeDefinitionPrimitive'
+          optional: 'ParameterTypeDefinitionOptional'
+
+    PrimitiveParameterValueType:
+      title: PrimitiveParameterValueType
       example: String
       description: What type of value this parameter expects
       enum:
@@ -184,6 +203,23 @@ components:
         - Boolean
         - Float
       type: string
+
+    ParameterTypeDefinitionPrimitive:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinition'
+      properties:
+        primitive_type:
+          $ref: '#/components/schemas/PrimitiveParameterValueType'
+
+    ParameterTypeDefinitionOptional:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinition'
+      properties:
+        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
+        optional_type:
+          $ref: ParameterTypeDefinition
 
     # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can
     # be used as parameter definitions.

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -58,7 +58,10 @@ class TestRunSetsApiController {
       """
       [ {
         "output_name" : "myWorkflow.myCall.outputName1",
-        "output_type" : "String",
+        "output_type" : {
+          "type" : "primitive",
+          "primitive_type" : "String"
+        },
         "record_attribute" : "foo_rating"
       } ]""";
 
@@ -68,14 +71,14 @@ class TestRunSetsApiController {
           "workflow_url" : "%s",
           "workflow_input_definitions" : [ {
             "input_name" : "myworkflow.mycall.inputname1",
-            "input_type" : "String",
+            "input_type" : { "type": "primitive", "primitive_type": "String" },
             "source" : {
               "type" : "literal",
               "parameter_value" : "literal value"
             }
           }, {
             "input_name" : "myworkflow.mycall.inputname2",
-            "input_type" : "Int",
+            "input_type" : { "type": "primitive", "primitive_type": "Int" },
             "source" : {
               "type" : "record_lookup",
               "record_attribute" : "MY_RECORD_ATTRIBUTE"

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildInputs.java
@@ -20,28 +20,31 @@ class TestInputGeneratorBuildInputs {
   void stringLiteral() throws JsonProcessingException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
-            List.of(literalFooParameter("String", "\"hello world\"")), emptyRecord());
+            List.of(literalPrimitiveFooParameter("String", "\"hello world\"")), emptyRecord());
     assertEquals(Map.of("literal_foo", "hello world"), actual);
   }
 
   @Test
   void intLiteral() throws JsonProcessingException {
     Map<String, Object> actual =
-        InputGenerator.buildInputs(List.of(literalFooParameter("Int", "1")), emptyRecord());
+        InputGenerator.buildInputs(
+            List.of(literalPrimitiveFooParameter("Int", "1")), emptyRecord());
     assertEquals(Map.of("literal_foo", 1), actual);
   }
 
   @Test
   void booleanLiteral() throws JsonProcessingException {
     Map<String, Object> actual =
-        InputGenerator.buildInputs(List.of(literalFooParameter("Boolean", "false")), emptyRecord());
+        InputGenerator.buildInputs(
+            List.of(literalPrimitiveFooParameter("Boolean", "false")), emptyRecord());
     assertEquals(Map.of("literal_foo", false), actual);
   }
 
   @Test
   void floatLiteral() throws JsonProcessingException {
     Map<String, Object> actual =
-        InputGenerator.buildInputs(List.of(literalFooParameter("Float", "1.1")), emptyRecord());
+        InputGenerator.buildInputs(
+            List.of(literalPrimitiveFooParameter("Float", "1.1")), emptyRecord());
     assertEquals(Map.of("literal_foo", 1.1), actual);
   }
 
@@ -83,7 +86,7 @@ class TestInputGeneratorBuildInputs {
         InputGenerator.buildInputs(
             List.of(
                 fooRatingRecordLookupParameter("String"),
-                literalFooParameter("String", "\"hello world\"")),
+                literalPrimitiveFooParameter("String", "\"hello world\"")),
             fooRatingRecord("\"exquisite\""));
     assertEquals(
         Map.of(
@@ -93,13 +96,13 @@ class TestInputGeneratorBuildInputs {
   }
 
   // Stock Parameter definitions:
-  private static WorkflowInputDefinition literalFooParameter(
+  private static WorkflowInputDefinition literalPrimitiveFooParameter(
       String parameterType, String rawLiteralJson) throws JsonProcessingException {
     String paramDefinitionJson =
         """
         {
           "input_name": "literal_foo",
-          "input_type": "%s",
+          "input_type": { "type": "primitive", "primitive_type": "%s" },
           "source": {
             "type": "literal",
             "parameter_value": %s
@@ -118,7 +121,7 @@ class TestInputGeneratorBuildInputs {
         """
         {
           "input_name": "lookup_foo",
-          "input_type": "%s",
+          "input_type": { "type": "primitive", "primitive_type": "%s" },
           "source": {
             "type": "record_lookup",
             "record_attribute": "foo-rating"

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPoller.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPoller.java
@@ -65,7 +65,7 @@ public class TestSmartRunsPoller {
         [
           {
             "output_name": "wf_hello.hello.salutation",
-            "output_type": "String",
+            "output_type": { "type": "primitive", "primitive_type": "String" },
             "record_attribute": "foo_name"
           }
         ]

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGenerator.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGenerator.java
@@ -26,7 +26,7 @@ class TestOutputGenerator {
         [
           {
             "output_name":"myWorkflow.out",
-            "output_type":"%s",
+            "output_type": { "type": "primitive", "primitive_type": "%s" },
             "record_attribute":"%s"
           }
         ]
@@ -96,12 +96,12 @@ class TestOutputGenerator {
         [
           {
             "output_name":"myWorkflow.name",
-            "output_type":"String",
+            "output_type": { "type": "primitive", "primitive_type": "String" },
             "record_attribute":"foo_name"
           },
           {
             "output_name":"myWorkflow.rating",
-            "output_type":"Float",
+            "output_type": { "type": "primitive", "primitive_type": "Float" },
             "record_attribute":"foo_rating"
           }
         ]
@@ -130,7 +130,7 @@ class TestOutputGenerator {
         [
           {
             "output_name":"myWorkflow.naem",
-            "output_type":"String",
+            "output_type": { "type": "primitive", "primitive_type": "String" },
             "record_attribute":"foo_name"
           }
         ]


### PR DESCRIPTION
None of the internal wiring to support them, just add the ability to define optional types in the API spec (and fix up tests!)