### PR TITLE
BW-1474: Add File types as inputs

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -202,6 +202,7 @@ components:
         - Int
         - Boolean
         - Float
+        - File
       type: string
 
     ParameterTypeDefinitionPrimitive:

--- a/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
+++ b/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
@@ -19,6 +19,7 @@ import io.opencensus.tags.Tags;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class MetricsUtil {
   private MetricsUtil() {}
@@ -147,7 +148,7 @@ public final class MetricsUtil {
             TAGKEY_STATUS,
             OutcomeStatus.SUCCESS,
             TAGKEY_FILE_SCHEME,
-            scheme,
+            Optional.ofNullable(scheme).orElse("/"),
             TAGKEY_FILE_FROM_TYPE,
             fromType),
         M_FILE_PARSED_COUNT,

--- a/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
+++ b/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
@@ -33,6 +33,7 @@ public final class MetricsUtil {
       INBOUND_REQUEST_METRICS + "/records-per-request";
   public static final String METHOD_METRICS = METRICS_PREFIX + "method";
   public static final String EVENT_METRICS = METRICS_PREFIX + "event";
+  public static final String FILE_PARSE_METRICS = EVENT_METRICS + "/files/parsed";
 
   public static final Measure.MeasureDouble M_METHOD_DURATION_MS =
       Measure.MeasureDouble.create(METHOD_METRICS, "Duration of method runs", "ms");
@@ -42,6 +43,9 @@ public final class MetricsUtil {
 
   public static final Measure.MeasureLong M_EVENT_COUNT =
       Measure.MeasureLong.create(EVENT_METRICS, "Counter for various events", "occurrences");
+
+  public static final Measure.MeasureLong M_FILE_PARSED_COUNT =
+      Measure.MeasureLong.create(EVENT_METRICS, "Counter for file parse operations", "occurrences");
 
   public static final Measure.MeasureLong M_RECORDS_PER_REQUEST =
       Measure.MeasureLong.create(
@@ -55,6 +59,9 @@ public final class MetricsUtil {
 
   public static final TagKey TAGKEY_NAME = TagKey.create("name");
   public static final TagKey TAGKEY_STATUS = TagKey.create("status");
+
+  public static final TagKey TAGKEY_FILE_SCHEME = TagKey.create("scheme");
+  public static final TagKey TAGKEY_FILE_FROM_TYPE = TagKey.create("from-type");
 
   public enum OutcomeStatus {
     SUCCESS("SUCCESS"),
@@ -126,16 +133,38 @@ public final class MetricsUtil {
         sinceInMilliseconds(startTimeNs));
   }
 
-  public static void incrementEventCounter(String eventName) {
-    increaseEventCounter(eventName, 1L);
-  }
-
   public static void recordRecordsInRequest(long numRecordIds) {
     recordTaggedStat(Map.of(), M_RECORDS_PER_REQUEST, numRecordIds);
   }
 
   public static void increaseEventCounter(String eventName, long count) {
     recordTaggedStat(Map.of(TAGKEY_NAME, eventName), M_EVENT_COUNT, count);
+  }
+
+  public static void incrementSuccessfulFileParseCounter(String scheme, String fromType) {
+    recordTaggedStat(
+        Map.of(
+            TAGKEY_STATUS,
+            OutcomeStatus.SUCCESS,
+            TAGKEY_FILE_SCHEME,
+            scheme,
+            TAGKEY_FILE_FROM_TYPE,
+            fromType),
+        M_FILE_PARSED_COUNT,
+        1L);
+  }
+
+  public static void incrementUnsuccessfulFileParseCounter(Object badValue) {
+    recordTaggedStat(
+        Map.of(
+            TAGKEY_STATUS,
+            OutcomeStatus.FAILURE,
+            TAGKEY_FILE_SCHEME,
+            "N/A",
+            TAGKEY_FILE_FROM_TYPE,
+            badValue.getClass().getSimpleName()),
+        M_FILE_PARSED_COUNT,
+        1L);
   }
 
   public static double sinceInMilliseconds(long startTimeNs) {
@@ -210,6 +239,12 @@ public final class MetricsUtil {
               M_EVENT_COUNT,
               Aggregation.Count.create(),
               List.of(TAGKEY_NAME)),
+          View.create(
+              View.Name.create(FILE_PARSE_METRICS),
+              "Counter for file parse operations",
+              M_FILE_PARSED_COUNT,
+              Aggregation.Count.create(),
+              List.of(TAGKEY_STATUS, TAGKEY_FILE_SCHEME)),
           View.create(
               View.Name.create(RECORDS_PER_REQUEST_METRICS),
               "Stats related to inbound requests",

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -24,6 +24,7 @@ import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
 import bio.terra.cbas.runsets.inputs.InputGenerator;
+import bio.terra.cbas.runsets.types.CoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
@@ -241,17 +242,26 @@ public class RunSetsApiController implements RunSetsApi {
     ArrayList<RunStateResponse> runStateResponseList = new ArrayList<>();
 
     for (RecordResponse record : recordResponses) {
-      // Build the inputs set from workflow parameter definitions and the fetched record
-      Map<String, Object> workflowInputs =
-          InputGenerator.buildInputs(request.getWorkflowInputDefinitions(), record);
-
-      // Submit the workflow, get its ID and store the Run to database
       RunId workflowResponse;
       UUID runId = UUID.randomUUID();
+
       try {
+        // Build the inputs set from workflow parameter definitions and the fetched record
+        Map<String, Object> workflowInputs =
+            InputGenerator.buildInputs(request.getWorkflowInputDefinitions(), record);
+
+        // Submit the workflow, get its ID and store the Run to database
         workflowResponse = cromwellService.submitWorkflow(request.getWorkflowUrl(), workflowInputs);
         runStateResponseList.add(
             storeRun(runId, workflowResponse.getRunId(), runSet, record.getId(), UNKNOWN, null));
+      } catch (CoercionException e) {
+        String errorMsg =
+            String.format(
+                "Input generation failed for record %s. Coercion error: %s",
+                record.getId(), e.getMessage());
+        log.warn(errorMsg, e);
+        runStateResponseList.add(
+            storeRun(runId, null, runSet, record.getId(), SYSTEM_ERROR, errorMsg + e.getMessage()));
       } catch (cromwell.client.ApiException e) {
         String errorMsg =
             String.format(

--- a/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
@@ -26,7 +26,7 @@ public class InputGenerator {
           .build();
 
   public static Map<String, Object> buildInputs(
-      List<WorkflowInputDefinition> inputDefinitions, RecordResponse record)
+      List<WorkflowInputDefinition> inputDefinitions, RecordResponse recordResponse)
       throws CoercionException {
     Map<String, Object> params = new HashMap<>();
     for (WorkflowInputDefinition param : inputDefinitions) {
@@ -37,7 +37,7 @@ public class InputGenerator {
       } else {
         String attributeName =
             ((ParameterDefinitionRecordLookup) param.getSource()).getRecordAttribute();
-        parameterValue = record.getAttributes().get(attributeName);
+        parameterValue = recordResponse.getAttributes().get(attributeName);
       }
 
       // Convert into an appropriate CbasValue:

--- a/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
@@ -4,6 +4,8 @@ import bio.terra.cbas.model.ParameterDefinition;
 import bio.terra.cbas.model.ParameterDefinitionLiteralValue;
 import bio.terra.cbas.model.ParameterDefinitionRecordLookup;
 import bio.terra.cbas.model.WorkflowInputDefinition;
+import bio.terra.cbas.runsets.types.CbasValue;
+import bio.terra.cbas.runsets.types.CoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -24,7 +26,8 @@ public class InputGenerator {
           .build();
 
   public static Map<String, Object> buildInputs(
-      List<WorkflowInputDefinition> inputDefinitions, RecordResponse record) {
+      List<WorkflowInputDefinition> inputDefinitions, RecordResponse record)
+      throws CoercionException {
     Map<String, Object> params = new HashMap<>();
     for (WorkflowInputDefinition param : inputDefinitions) {
       String parameterName = param.getInputName();
@@ -36,7 +39,11 @@ public class InputGenerator {
             ((ParameterDefinitionRecordLookup) param.getSource()).getRecordAttribute();
         parameterValue = record.getAttributes().get(attributeName);
       }
-      params.put(parameterName, parameterValue);
+
+      // Convert into an appropriate CbasValue:
+      CbasValue cbasValue = CbasValue.parseValue(param.getInputType(), parameterValue);
+
+      params.put(parameterName, cbasValue.asCromwellInput());
     }
     return params;
   }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
@@ -1,0 +1,25 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasBoolean implements CbasValue {
+  private final Boolean value;
+
+  /*
+  Private constructor. Use 'parse' instead.
+   */
+  private CbasBoolean(Boolean value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value;
+  }
+
+  public static CbasBoolean parse(Object value) throws CoercionException {
+    if (value instanceof Boolean b) {
+      return new CbasBoolean(b);
+    } else {
+      throw new TypeCoercionException(value, "Int");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
@@ -1,0 +1,40 @@
+package bio.terra.cbas.runsets.types;
+
+import static bio.terra.cbas.common.MetricsUtil.incrementSuccessfulFileParseCounter;
+import static bio.terra.cbas.common.MetricsUtil.incrementUnsuccessfulFileParseCounter;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class CbasFile implements CbasValue {
+  private final String value;
+
+  /*
+  Private constructor. Use 'parseFile' instead.
+   */
+  private CbasFile(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value;
+  }
+
+  public static CbasFile parse(Object value) throws CoercionException {
+    if (value instanceof String strValue) {
+      try {
+        URI uri = new URI(strValue);
+        incrementSuccessfulFileParseCounter(uri.getScheme(), "String");
+        return new CbasFile(uri.toString());
+      } catch (URISyntaxException e) {
+        incrementUnsuccessfulFileParseCounter("String");
+        throw new ValueCoercionException("String", "File", e.getMessage());
+      }
+    } else if (value instanceof CbasFile fileValue) {
+      return new CbasFile(fileValue.value);
+    } else {
+      throw new TypeCoercionException(value, "String");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
@@ -22,19 +22,21 @@ public class CbasFile implements CbasValue {
   }
 
   public static CbasFile parse(Object value) throws CoercionException {
+    String fromType = value.getClass().getSimpleName();
+    String toType = "File";
     if (value instanceof String strValue) {
       try {
         URI uri = new URI(strValue);
-        incrementSuccessfulFileParseCounter(uri.getScheme(), "String");
+        incrementSuccessfulFileParseCounter(uri.getScheme(), fromType);
         return new CbasFile(uri.toString());
       } catch (URISyntaxException e) {
-        incrementUnsuccessfulFileParseCounter("String");
-        throw new ValueCoercionException("String", "File", e.getMessage());
+        incrementUnsuccessfulFileParseCounter(fromType);
+        throw new ValueCoercionException(fromType, toType, e.getMessage());
       }
     } else if (value instanceof CbasFile fileValue) {
       return new CbasFile(fileValue.value);
     } else {
-      throw new TypeCoercionException(value, "String");
+      throw new TypeCoercionException(value, toType);
     }
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
@@ -1,0 +1,27 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasFloat implements CbasValue {
+  private final Double value;
+
+  /*
+  Private constructor. Use 'parse' instead.
+   */
+  private CbasFloat(Double value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value;
+  }
+
+  public static CbasFloat parse(Object value) throws CoercionException {
+    if (value instanceof Float f) {
+      return new CbasFloat(f.doubleValue());
+    } else if (value instanceof Double d) {
+      return new CbasFloat(d);
+    } else {
+      throw new TypeCoercionException(value, "Double");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
@@ -1,0 +1,27 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasInt implements CbasValue {
+  private final Long value;
+
+  /*
+  Private constructor. Use 'parse' instead.
+   */
+  private CbasInt(Long value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value;
+  }
+
+  public static CbasInt parse(Object value) throws CoercionException {
+    if (value instanceof Integer i) {
+      return new CbasInt(i.longValue());
+    } else if (value instanceof Long l) {
+      return new CbasInt(l);
+    } else {
+      throw new TypeCoercionException(value, "Int");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptional.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptional.java
@@ -1,0 +1,3 @@
+package bio.terra.cbas.runsets.types;
+
+public interface CbasOptional extends CbasValue {}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
@@ -1,0 +1,8 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasOptionalNone implements CbasOptional {
+  @Override
+  public Object asCromwellInput() {
+    return null;
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
@@ -1,0 +1,15 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasOptionalSome implements CbasOptional {
+
+  private final CbasValue value;
+
+  public CbasOptionalSome(CbasValue value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value.asCromwellInput();
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
@@ -1,0 +1,21 @@
+package bio.terra.cbas.runsets.types;
+
+public class CbasString implements CbasValue {
+  private final String value;
+
+  /*
+  Private constructor. Use 'parse' instead.
+   */
+  private CbasString(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public Object asCromwellInput() {
+    return value;
+  }
+
+  public static CbasString parse(Object value) {
+    return new CbasString(value.toString());
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -1,0 +1,31 @@
+package bio.terra.cbas.runsets.types;
+
+import bio.terra.cbas.model.ParameterTypeDefinition;
+import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
+import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+
+public interface CbasValue {
+  Object asCromwellInput();
+
+  static CbasValue parseValue(ParameterTypeDefinition parameterType, Object value)
+      throws CoercionException {
+    if (parameterType instanceof ParameterTypeDefinitionPrimitive primitiveDefinition) {
+      return switch (primitiveDefinition.getPrimitiveType()) {
+        case STRING -> CbasString.parse(value);
+        case INT -> CbasInt.parse(value);
+        case BOOLEAN -> CbasBoolean.parse(value);
+        case FLOAT -> CbasFloat.parse(value);
+        case FILE -> CbasFile.parse(value);
+      };
+    } else if (parameterType instanceof ParameterTypeDefinitionOptional optionalDefinition) {
+      if (value == null) {
+        return new CbasOptionalNone();
+      } else {
+        var innerType = optionalDefinition.getOptionalType();
+        return new CbasOptionalSome(parseValue(innerType, value));
+      }
+    } else {
+      throw new TypeCoercionException(value, parameterType.toString());
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CoercionException.java
@@ -1,0 +1,18 @@
+package bio.terra.cbas.runsets.types;
+
+public abstract class CoercionException extends Exception {
+  private final String fromType;
+  private final String toType;
+  private final String reason;
+
+  public CoercionException(String fromType, String toType, String reason) {
+    this.fromType = fromType;
+    this.toType = toType;
+    this.reason = reason;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Coercion from %s to %s failed. %s".formatted(fromType, toType, reason);
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CoercionException.java
@@ -5,7 +5,7 @@ public abstract class CoercionException extends Exception {
   private final String toType;
   private final String reason;
 
-  public CoercionException(String fromType, String toType, String reason) {
+  protected CoercionException(String fromType, String toType, String reason) {
     this.fromType = fromType;
     this.toType = toType;
     this.reason = reason;

--- a/service/src/main/java/bio/terra/cbas/runsets/types/TypeCoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/TypeCoercionException.java
@@ -1,0 +1,12 @@
+package bio.terra.cbas.runsets.types;
+
+public class TypeCoercionException extends CoercionException {
+  public TypeCoercionException(String fromType, String toType) {
+    super(fromType, toType, "Coercion not supported between these types.");
+  }
+
+  public TypeCoercionException(Object badValue, String toType) {
+    super(
+        toType, badValue.getClass().getSimpleName(), "Coercion not supported between these types.");
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/ValueCoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/ValueCoercionException.java
@@ -1,0 +1,7 @@
+package bio.terra.cbas.runsets.types;
+
+public class ValueCoercionException extends CoercionException {
+  public ValueCoercionException(String fromType, String toType, String reason) {
+    super(fromType, toType, "Coercion supported but failed: %s.".formatted(reason));
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -71,7 +71,7 @@ class TestRunSetsApiController {
         "record_attribute" : "foo_rating"
       } ]""";
 
-  private String requestTemplate =
+  private final String requestTemplate =
       """
         {
           "workflow_url" : "%s",
@@ -132,13 +132,13 @@ class TestRunSetsApiController {
     final String cromwellWorkflowId3 = UUID.randomUUID().toString();
     HashMap<String, Object> workflowInputsMap1 = new HashMap<>();
     workflowInputsMap1.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap1.put("myworkflow.mycall.inputname2", 100);
+    workflowInputsMap1.put("myworkflow.mycall.inputname2", 100L);
     HashMap<String, Object> workflowInputsMap2 = new HashMap<>();
     workflowInputsMap2.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap2.put("myworkflow.mycall.inputname2", 200);
+    workflowInputsMap2.put("myworkflow.mycall.inputname2", 200L);
     HashMap<String, Object> workflowInputsMap3 = new HashMap<>();
     workflowInputsMap3.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap3.put("myworkflow.mycall.inputname2", 300);
+    workflowInputsMap3.put("myworkflow.mycall.inputname2", 300L);
     String request =
         requestTemplate.formatted(
             workflowUrl,
@@ -222,8 +222,6 @@ class TestRunSetsApiController {
   void tooManyRecordIds() throws Exception {
     final String recordIds = "[ \"RECORD1\", \"RECORD2\", \"RECORD3\", \"RECORD4\" ]";
     final int recordAttributeValue = 100;
-    RecordAttributes recordAttributes = new RecordAttributes();
-    recordAttributes.put(recordAttribute, recordAttributeValue);
 
     String request =
         requestTemplate.formatted(workflowUrl, outputDefinitionAsString, recordType, recordIds);
@@ -244,8 +242,6 @@ class TestRunSetsApiController {
     final int recordAttributeValue2 = 200;
     RecordAttributes recordAttributes1 = new RecordAttributes();
     recordAttributes1.put(recordAttribute, recordAttributeValue1);
-    RecordAttributes recordAttributes2 = new RecordAttributes();
-    recordAttributes2.put(recordAttribute, recordAttributeValue2);
 
     String request =
         requestTemplate.formatted(
@@ -277,14 +273,14 @@ class TestRunSetsApiController {
   }
 }
 
-class UnitTestRunSetsApiController {
-  private CbasApiConfiguration config = new CbasApiConfiguration();
-  private RunSetRequest request = new RunSetRequest();
+class TestRunSetsApiControllerUnits {
+  private final CbasApiConfiguration config = new CbasApiConfiguration();
+  private final RunSetRequest request = new RunSetRequest();
 
   @Test
   void testRequestValidityFewerThanMax() {
     config.setRunSetsMaximumRecordIds(2);
-    request.setWdsRecords(new WdsRecordSet().recordIds(Arrays.asList("r1")));
+    request.setWdsRecords(new WdsRecordSet().recordIds(List.of("r1")));
     assertTrue(RunSetsApiController.validateRequest(request, config).isEmpty());
   }
 

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildOptionalInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildOptionalInputs.java
@@ -5,6 +5,7 @@ import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.emptyRecord;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bio.terra.cbas.runsets.types.CoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,7 +20,7 @@ class TestInputGeneratorBuildOptionalInputs {
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @Test
-  void optionalStringProvided() throws JsonProcessingException {
+  void optionalStringProvided() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithOptionalFooRatingParameter("String")),
@@ -28,7 +29,7 @@ class TestInputGeneratorBuildOptionalInputs {
   }
 
   @Test
-  void optionalStringNotProvided() throws JsonProcessingException {
+  void optionalStringNotProvided() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithOptionalFooRatingParameter("String")), emptyRecord());

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildPrimitiveInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildPrimitiveInputs.java
@@ -7,11 +7,13 @@ import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWit
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.cbas.runsets.types.CoercionException;
+import bio.terra.cbas.runsets.types.ValueCoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TestInputGeneratorBuildPrimitiveInputs {
@@ -31,7 +33,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   void intLiteral() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(List.of(fooRatingLiteralParameter("Int", "1")), emptyRecord());
-    assertEquals(Map.of("literal_foo", 1), actual);
+    assertEquals(Map.of("literal_foo", 1L), actual);
   }
 
   @Test
@@ -51,6 +53,24 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
+  void validFileLiteral() throws JsonProcessingException, CoercionException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(fooRatingLiteralParameter("File", "\"gs://bucket/file.txt\"")), emptyRecord());
+    assertEquals(Map.of("literal_foo", "gs://bucket/file.txt"), actual);
+  }
+
+  @Test
+  void invalidFileLiteral() {
+
+    Assertions.assertThrows(
+        ValueCoercionException.class,
+        () ->
+            InputGenerator.buildInputs(
+                List.of(fooRatingLiteralParameter("File", "\"not a file\"")), emptyRecord()));
+  }
+
+  @Test
   void stringRecordLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
@@ -64,7 +84,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingRecordLookupParameter("Int")), wdsRecordWithFooRating("1000"));
-    assertEquals(Map.of("lookup_foo", 1000), actual);
+    assertEquals(Map.of("lookup_foo", 1000L), actual);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildPrimitiveInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildPrimitiveInputs.java
@@ -6,6 +6,7 @@ import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.emptyRecord;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bio.terra.cbas.runsets.types.CoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,7 +20,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @Test
-  void stringLiteral() throws JsonProcessingException {
+  void stringLiteral() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingLiteralParameter("String", "\"hello world\"")), emptyRecord());
@@ -27,14 +28,14 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void intLiteral() throws JsonProcessingException {
+  void intLiteral() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(List.of(fooRatingLiteralParameter("Int", "1")), emptyRecord());
     assertEquals(Map.of("literal_foo", 1), actual);
   }
 
   @Test
-  void booleanLiteral() throws JsonProcessingException {
+  void booleanLiteral() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingLiteralParameter("Boolean", "false")), emptyRecord());
@@ -42,7 +43,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void floatLiteral() throws JsonProcessingException {
+  void floatLiteral() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingLiteralParameter("Float", "1.1")), emptyRecord());
@@ -50,7 +51,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void stringRecordLookup() throws JsonProcessingException {
+  void stringRecordLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingRecordLookupParameter("String")),
@@ -59,7 +60,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void numberRecordLookup() throws JsonProcessingException {
+  void numberRecordLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingRecordLookupParameter("Int")), wdsRecordWithFooRating("1000"));
@@ -67,7 +68,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void booleanRecordLookup() throws JsonProcessingException {
+  void booleanRecordLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingRecordLookupParameter("Boolean")), wdsRecordWithFooRating("true"));
@@ -75,7 +76,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void floatRecordLookup() throws JsonProcessingException {
+  void floatRecordLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(fooRatingRecordLookupParameter("Float")), wdsRecordWithFooRating("1000.0001"));
@@ -83,7 +84,7 @@ class TestInputGeneratorBuildPrimitiveInputs {
   }
 
   @Test
-  void mixedLiteralAndLookup() throws JsonProcessingException {
+  void mixedLiteralAndLookup() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
@@ -9,7 +9,7 @@ import bio.terra.cbas.model.PrimitiveParameterValueType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestCoercions {
+class TestCoercions {
 
   void testValidStringFileCoercion(String input) throws CoercionException {
     var actual =

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
@@ -1,0 +1,61 @@
+package bio.terra.cbas.runsets.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestCoercions {
+
+  void testValidStringFileCoercion(String input) throws CoercionException {
+    var actual =
+        CbasValue.parseValue(
+            new ParameterTypeDefinitionPrimitive().primitiveType(PrimitiveParameterValueType.FILE),
+            input);
+    assertThat(actual, instanceOf(CbasFile.class));
+    assertEquals(actual.asCromwellInput(), input);
+  }
+
+  @Test
+  void testValidLocalStringFileCoercion() throws CoercionException {
+    testValidStringFileCoercion("/var/lib/file.txt");
+  }
+
+  @Test
+  void testValidGcsStringFileCoercion() throws CoercionException {
+    testValidStringFileCoercion("gs://bucket/dir/file.txt");
+  }
+
+  @Test
+  void testValidAzStringFileCoercion() throws CoercionException {
+    testValidStringFileCoercion("az://bucket/dir/file.txt");
+  }
+
+  @Test
+  void testInvalidFileCoercionInputValue() {
+    String input = "\"not a file\"";
+    Assertions.assertThrows(
+        ValueCoercionException.class,
+        () ->
+            CbasValue.parseValue(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.FILE),
+                input));
+  }
+
+  @Test
+  void testInvalidFileCoercionInputType() {
+    Object input = 73;
+    Assertions.assertThrows(
+        TypeCoercionException.class,
+        () ->
+            CbasValue.parseValue(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.FILE),
+                input));
+  }
+}


### PR DESCRIPTION
To aid validation, includes type and value coercion from Json/WDS types to Cbas recognized types, and on to Cromwell inputs.

From the ticket.

AC:

- File inputs must be declarable via our input definitions.
- Input files are correctly passed along to Cromwell if used in input definitions
- Basic string validation of the file path to make sure it looks like a file
  - (put pieces in place in case we need more validation later)

Tests:

- Unit tests against the inputs generator

Metrics:

- Count of files that fail validation and those that don’t
- Counts of GCS, Azure, local, DRS file paths