### PR TITLE
BW-1475: Add File types as outputs

### DIFF
--- a/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
+++ b/service/src/main/java/bio/terra/cbas/common/MetricsUtil.java
@@ -46,7 +46,8 @@ public final class MetricsUtil {
       Measure.MeasureLong.create(EVENT_METRICS, "Counter for various events", "occurrences");
 
   public static final Measure.MeasureLong M_FILE_PARSED_COUNT =
-      Measure.MeasureLong.create(EVENT_METRICS, "Counter for file parse operations", "occurrences");
+      Measure.MeasureLong.create(
+          FILE_PARSE_METRICS, "Counter for file parse operations", "occurrences");
 
   public static final Measure.MeasureLong M_RECORDS_PER_REQUEST =
       Measure.MeasureLong.create(

--- a/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
@@ -43,7 +43,7 @@ public class InputGenerator {
       // Convert into an appropriate CbasValue:
       CbasValue cbasValue = CbasValue.parseValue(param.getInputType(), parameterValue);
 
-      params.put(parameterName, cbasValue.asCromwellInput());
+      params.put(parameterName, cbasValue.asSerializableValue());
     }
     return params;
   }

--- a/service/src/main/java/bio/terra/cbas/runsets/outputs/OutputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/outputs/OutputGenerator.java
@@ -3,6 +3,8 @@ package bio.terra.cbas.runsets.outputs;
 import bio.terra.cbas.common.exceptions.WorkflowOutputNotFoundException;
 import bio.terra.cbas.model.ParameterTypeDefinition;
 import bio.terra.cbas.model.WorkflowOutputDefinition;
+import bio.terra.cbas.runsets.types.CbasValue;
+import bio.terra.cbas.runsets.types.CoercionException;
 import java.util.List;
 import java.util.Map;
 import org.databiosphere.workspacedata.model.RecordAttributes;
@@ -11,7 +13,7 @@ public class OutputGenerator {
 
   public static RecordAttributes buildOutputs(
       List<WorkflowOutputDefinition> outputDefinitions, Object cromwellOutputs)
-      throws WorkflowOutputNotFoundException {
+      throws WorkflowOutputNotFoundException, CoercionException {
     RecordAttributes outputRecordAttributes = new RecordAttributes();
     for (WorkflowOutputDefinition outputDefinition : outputDefinitions) {
       String outputName = outputDefinition.getOutputName();
@@ -31,8 +33,10 @@ public class OutputGenerator {
         outputValue = ((Map<String, Object>) cromwellOutputs).get(outputName);
       }
 
+      var coercedValue = CbasValue.parseValue(outputDefinition.getOutputType(), outputValue);
+
       String attributeName = outputDefinition.getRecordAttribute();
-      outputRecordAttributes.put(attributeName, outputValue);
+      outputRecordAttributes.put(attributeName, coercedValue.asSerializableValue());
     }
     return outputRecordAttributes;
   }

--- a/service/src/main/java/bio/terra/cbas/runsets/outputs/OutputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/outputs/OutputGenerator.java
@@ -1,5 +1,7 @@
 package bio.terra.cbas.runsets.outputs;
 
+import static bio.terra.cbas.common.MetricsUtil.increaseEventCounter;
+
 import bio.terra.cbas.common.exceptions.WorkflowOutputNotFoundException;
 import bio.terra.cbas.model.ParameterTypeDefinition;
 import bio.terra.cbas.model.WorkflowOutputDefinition;
@@ -34,6 +36,7 @@ public class OutputGenerator {
       }
 
       var coercedValue = CbasValue.parseValue(outputDefinition.getOutputType(), outputValue);
+      increaseEventCounter("files-updated-in-wds", coercedValue.countFiles());
 
       String attributeName = outputDefinition.getRecordAttribute();
       outputRecordAttributes.put(attributeName, coercedValue.asSerializableValue());

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
@@ -15,6 +15,11 @@ public class CbasBoolean implements CbasValue {
     return value;
   }
 
+  @Override
+  public long countFiles() {
+    return 0L;
+  }
+
   public static CbasBoolean parse(Object value) throws CoercionException {
     if (value instanceof Boolean b) {
       return new CbasBoolean(b);

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
@@ -11,7 +11,7 @@ public class CbasBoolean implements CbasValue {
   }
 
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return value;
   }
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
@@ -17,7 +17,7 @@ public class CbasFile implements CbasValue {
   }
 
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return value;
   }
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
@@ -21,6 +21,11 @@ public class CbasFile implements CbasValue {
     return value;
   }
 
+  @Override
+  public long countFiles() {
+    return 1L;
+  }
+
   public static CbasFile parse(Object value) throws CoercionException {
     String fromType = value.getClass().getSimpleName();
     String toType = "File";

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
@@ -15,6 +15,11 @@ public class CbasFloat implements CbasValue {
     return value;
   }
 
+  @Override
+  public long countFiles() {
+    return 0L;
+  }
+
   public static CbasFloat parse(Object value) throws CoercionException {
     if (value instanceof Float f) {
       return new CbasFloat(f.doubleValue());

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFloat.java
@@ -11,7 +11,7 @@ public class CbasFloat implements CbasValue {
   }
 
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return value;
   }
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
@@ -15,6 +15,11 @@ public class CbasInt implements CbasValue {
     return value;
   }
 
+  @Override
+  public long countFiles() {
+    return 0L;
+  }
+
   public static CbasInt parse(Object value) throws CoercionException {
     if (value instanceof Integer i) {
       return new CbasInt(i.longValue());

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasInt.java
@@ -11,7 +11,7 @@ public class CbasInt implements CbasValue {
   }
 
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return value;
   }
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
@@ -2,7 +2,7 @@ package bio.terra.cbas.runsets.types;
 
 public class CbasOptionalNone implements CbasOptional {
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return null;
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalNone.java
@@ -5,4 +5,9 @@ public class CbasOptionalNone implements CbasOptional {
   public Object asSerializableValue() {
     return null;
   }
+
+  @Override
+  public long countFiles() {
+    return 0L;
+  }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
@@ -12,4 +12,9 @@ public class CbasOptionalSome implements CbasOptional {
   public Object asSerializableValue() {
     return value.asSerializableValue();
   }
+
+  @Override
+  public long countFiles() {
+    return value.countFiles();
+  }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasOptionalSome.java
@@ -9,7 +9,7 @@ public class CbasOptionalSome implements CbasOptional {
   }
 
   @Override
-  public Object asCromwellInput() {
-    return value.asCromwellInput();
+  public Object asSerializableValue() {
+    return value.asSerializableValue();
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
@@ -15,6 +15,11 @@ public class CbasString implements CbasValue {
     return value;
   }
 
+  @Override
+  public long countFiles() {
+    return 0L;
+  }
+
   public static CbasString parse(Object value) {
     return new CbasString(value.toString());
   }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
@@ -11,7 +11,7 @@ public class CbasString implements CbasValue {
   }
 
   @Override
-  public Object asCromwellInput() {
+  public Object asSerializableValue() {
     return value;
   }
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -5,7 +5,7 @@ import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
 
 public interface CbasValue {
-  Object asCromwellInput();
+  Object asSerializableValue();
 
   static CbasValue parseValue(ParameterTypeDefinition parameterType, Object value)
       throws CoercionException {

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -7,6 +7,13 @@ import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
 public interface CbasValue {
   Object asSerializableValue();
 
+  /**
+   * Count how many Files are in this value.
+   *
+   * @return count of files
+   */
+  long countFiles();
+
   static CbasValue parseValue(ParameterTypeDefinition parameterType, Object value)
       throws CoercionException {
     if (parameterType instanceof ParameterTypeDefinitionPrimitive primitiveDefinition) {

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestCoercions.java
@@ -17,7 +17,7 @@ class TestCoercions {
             new ParameterTypeDefinitionPrimitive().primitiveType(PrimitiveParameterValueType.FILE),
             input);
     assertThat(actual, instanceOf(CbasFile.class));
-    assertEquals(actual.asCromwellInput(), input);
+    assertEquals(actual.asSerializableValue(), input);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestFileCounting.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestFileCounting.java
@@ -1,0 +1,54 @@
+package bio.terra.cbas.runsets.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
+import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
+import org.junit.jupiter.api.Test;
+
+class TestFileCounting {
+
+  @Test
+  void testFileCountingForFileType() throws CoercionException {
+    CbasValue value =
+        CbasValue.parseValue(
+            new ParameterTypeDefinitionPrimitive().primitiveType(PrimitiveParameterValueType.FILE),
+            "gs://bucket/dir/file.txt");
+    assertEquals(1L, value.countFiles());
+  }
+
+  @Test
+  void testFileCountingForStringType() throws CoercionException {
+    CbasValue value =
+        CbasValue.parseValue(
+            new ParameterTypeDefinitionPrimitive()
+                .primitiveType(PrimitiveParameterValueType.STRING),
+            "gs://bucket/dir/file.txt");
+    assertEquals(0L, value.countFiles());
+  }
+
+  @Test
+  void testFileCountingForFilledOptionalFileType() throws CoercionException {
+    CbasValue value =
+        CbasValue.parseValue(
+            new ParameterTypeDefinitionOptional()
+                .optionalType(
+                    new ParameterTypeDefinitionPrimitive()
+                        .primitiveType(PrimitiveParameterValueType.FILE)),
+            "gs://bucket/dir/file.txt");
+    assertEquals(1L, value.countFiles());
+  }
+
+  @Test
+  void testFileCountingForEmptyOptionalFileType() throws CoercionException {
+    CbasValue value =
+        CbasValue.parseValue(
+            new ParameterTypeDefinitionOptional()
+                .optionalType(
+                    new ParameterTypeDefinitionPrimitive()
+                        .primitiveType(PrimitiveParameterValueType.FILE)),
+            null);
+    assertEquals(0L, value.countFiles());
+  }
+}


### PR DESCRIPTION
AC:

- File outputs must be declarable via our output definitions.
- File outputs must be correctly exported back to WDS if used in workflows.

Tests:

- Unit tests against the outputs generator

Metrics:

- Count files that are written back to the data tables (Sara wants to know: How many users are really using this “write to data table” feature?)