### PR TITLE
WM-1511, WM-1512: Array types in inputs

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -187,11 +187,13 @@ components:
       oneOf:
         - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'
         - $ref: '#/components/schemas/ParameterTypeDefinitionOptional'
+        - $ref: '#/components/schemas/ParameterTypeDefinitionArray'
       discriminator:
         propertyName: "type"
         mapping:
           primitive: 'ParameterTypeDefinitionPrimitive'
           optional: 'ParameterTypeDefinitionOptional'
+          array: 'ParameterTypeDefinitionArray'
 
     PrimitiveParameterValueType:
       title: PrimitiveParameterValueType
@@ -220,6 +222,15 @@ components:
       properties:
         # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
         optional_type:
+          $ref: ParameterTypeDefinition
+
+    ParameterTypeDefinitionArray:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinition'
+      properties:
+        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
+        array_type:
           $ref: ParameterTypeDefinition
 
     # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -220,7 +220,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/ParameterTypeDefinition'
       properties:
-        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
         optional_type:
           $ref: ParameterTypeDefinition
 
@@ -229,7 +228,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ParameterTypeDefinition'
       properties:
-        # Note: In quotes to remind us that this "type" is an API field, not an OpenAPI spec 'type':
+        non_empty:
+          type: boolean
+          default: false
         array_type:
           $ref: ParameterTypeDefinition
 

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -182,7 +182,7 @@ components:
           type: string
           description: Indicates what type of parameter type definition this is.
           required: true
-          enum: [ primitive, optional ]
+          enum: [ primitive, optional, array ]
           example: record_lookup
       oneOf:
         - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
@@ -22,13 +22,20 @@ public class CbasArray implements CbasOptional {
     return values.stream().map(CbasValue::countFiles).reduce(0L, Long::sum);
   }
 
-  public static CbasArray parseValue(ParameterTypeDefinition innerType, Object values)
-      throws CoercionException {
+  public static CbasArray parseValue(
+      ParameterTypeDefinition innerType, Object values, boolean nonEmpty) throws CoercionException {
     if (values instanceof List valueList) {
       List<CbasValue> coercedValues = new ArrayList<>();
       for (Object value : valueList) {
         coercedValues.add(CbasValue.parseValue(innerType, value));
       }
+      if (nonEmpty && coercedValues.isEmpty()) {
+        throw new ValueCoercionException(
+            values,
+            "Array[%s]".formatted(innerType),
+            "Non-empty array must have at least one value.");
+      }
+
       return new CbasArray(coercedValues);
     } else {
       throw new TypeCoercionException(values, "Array[%s]".formatted(innerType));

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
@@ -24,7 +24,7 @@ public class CbasArray implements CbasOptional {
 
   public static CbasArray parseValue(
       ParameterTypeDefinition innerType, Object values, boolean nonEmpty) throws CoercionException {
-    if (values instanceof List valueList) {
+    if (values instanceof List<?> valueList) {
       List<CbasValue> coercedValues = new ArrayList<>();
       for (Object value : valueList) {
         coercedValues.add(CbasValue.parseValue(innerType, value));

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
@@ -1,0 +1,37 @@
+package bio.terra.cbas.runsets.types;
+
+import bio.terra.cbas.model.ParameterTypeDefinition;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CbasArray implements CbasOptional {
+
+  private final List<CbasValue> values;
+
+  public CbasArray(List<CbasValue> values) {
+    this.values = values;
+  }
+
+  @Override
+  public Object asSerializableValue() {
+    return values.stream().map(CbasValue::asSerializableValue).toList();
+  }
+
+  @Override
+  public long countFiles() {
+    return values.stream().map(CbasValue::countFiles).reduce(0L, Long::sum);
+  }
+
+  public static CbasArray parseValue(ParameterTypeDefinition innerType, Object values)
+      throws CoercionException {
+    if (values instanceof List valueList) {
+      List<CbasValue> coercedValues = new ArrayList<>();
+      for (Object value : valueList) {
+        coercedValues.add(CbasValue.parseValue(innerType, value));
+      }
+      return new CbasArray(coercedValues);
+    } else {
+      throw new TypeCoercionException(values, "Array[%s]".formatted(innerType));
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
@@ -19,7 +19,7 @@ public class CbasArray implements CbasOptional {
 
   @Override
   public long countFiles() {
-    return values.stream().map(CbasValue::countFiles).reduce(0L, Long::sum);
+    return values.stream().mapToLong(CbasValue::countFiles).sum();
   }
 
   public static CbasArray parseValue(

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasBoolean.java
@@ -24,7 +24,7 @@ public class CbasBoolean implements CbasValue {
     if (value instanceof Boolean b) {
       return new CbasBoolean(b);
     } else {
-      throw new TypeCoercionException(value, "Int");
+      throw new TypeCoercionException(value, "Boolean");
     }
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasFile.java
@@ -36,7 +36,7 @@ public class CbasFile implements CbasValue {
         return new CbasFile(uri.toString());
       } catch (URISyntaxException e) {
         incrementUnsuccessfulFileParseCounter(fromType);
-        throw new ValueCoercionException(fromType, toType, e.getMessage());
+        throw new ValueCoercionException(value, toType, e.getMessage());
       }
     } else if (value instanceof CbasFile fileValue) {
       return new CbasFile(fileValue.value);

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.runsets.types;
 
 import bio.terra.cbas.model.ParameterTypeDefinition;
+import bio.terra.cbas.model.ParameterTypeDefinitionArray;
 import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
 
@@ -31,6 +32,9 @@ public interface CbasValue {
         var innerType = optionalDefinition.getOptionalType();
         return new CbasOptionalSome(parseValue(innerType, value));
       }
+    } else if (parameterType instanceof ParameterTypeDefinitionArray arrayDefinition) {
+      var innerType = arrayDefinition.getArrayType();
+      return CbasArray.parseValue(innerType, value);
     } else {
       throw new TypeCoercionException(value, parameterType.toString());
     }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -34,7 +34,7 @@ public interface CbasValue {
       }
     } else if (parameterType instanceof ParameterTypeDefinitionArray arrayDefinition) {
       var innerType = arrayDefinition.getArrayType();
-      return CbasArray.parseValue(innerType, value);
+      return CbasArray.parseValue(innerType, value, arrayDefinition.isNonEmpty());
     } else {
       throw new TypeCoercionException(value, parameterType.toString());
     }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/ValueCoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/ValueCoercionException.java
@@ -1,7 +1,10 @@
 package bio.terra.cbas.runsets.types;
 
 public class ValueCoercionException extends CoercionException {
-  public ValueCoercionException(String fromType, String toType, String reason) {
-    super(fromType, toType, "Coercion supported but failed: %s.".formatted(reason));
+  public ValueCoercionException(Object badValue, String toType, String reason) {
+    super(
+        badValue.getClass().getSimpleName(),
+        toType,
+        "Coercion supported but failed: %s.".formatted(reason));
   }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -68,4 +68,23 @@ public final class StockInputDefinitions {
 
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
+
+  public static WorkflowInputDefinition inputDefinitionWithArrayFooRatingParameter(
+      String arrayInnerType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": { "type": "array", "array_type": { "type": "primitive", "primitive_type": "%s" }},
+          "source": {
+            "type": "record_lookup",
+            "record_attribute": "foo-rating"
+          }
+        }"""
+            .formatted(arrayInnerType)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -70,18 +70,18 @@ public final class StockInputDefinitions {
   }
 
   public static WorkflowInputDefinition inputDefinitionWithArrayFooRatingParameter(
-      String arrayInnerType) throws JsonProcessingException {
+      Boolean nonEmpty, String arrayInnerType) throws JsonProcessingException {
     String paramDefinitionJson =
         """
         {
           "input_name": "lookup_foo",
-          "input_type": { "type": "array", "array_type": { "type": "primitive", "primitive_type": "%s" }},
+          "input_type": { "type": "array", "non_empty": %s, "array_type": { "type": "primitive", "primitive_type": "%s" }},
           "source": {
             "type": "record_lookup",
             "record_attribute": "foo-rating"
           }
         }"""
-            .formatted(arrayInnerType)
+            .formatted(nonEmpty, arrayInnerType)
             .stripIndent()
             .trim();
 

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -87,4 +87,24 @@ public final class StockInputDefinitions {
 
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
+
+  public static WorkflowInputDefinition inputDefinitionWithArrayLiteral(
+      Boolean nonEmpty, String arrayInnerType, String rawLiteralJson)
+      throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": { "type": "array", "non_empty": %s, "array_type": { "type": "primitive", "primitive_type": "%s" }},
+          "source": {
+            "type": "literal",
+            "parameter_value": %s
+          }
+        }"""
+            .formatted(nonEmpty, arrayInnerType, rawLiteralJson)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildArrayInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildArrayInputs.java
@@ -1,6 +1,8 @@
 package bio.terra.cbas.runsets.inputs;
 
 import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithArrayFooRatingParameter;
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithArrayLiteral;
+import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.emptyRecord;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,7 +18,7 @@ import org.junit.jupiter.api.Test;
 class TestInputGeneratorBuildArrayInputs {
 
   @Test
-  void zeroElementArray()
+  void zeroElementArrayLookup()
       throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
@@ -28,7 +30,18 @@ class TestInputGeneratorBuildArrayInputs {
   }
 
   @Test
-  void oneElementArray()
+  void zeroElementArrayLiteral()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayLiteral(false, "String", "[]")), emptyRecord());
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void oneElementArrayLookup()
       throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
@@ -40,7 +53,19 @@ class TestInputGeneratorBuildArrayInputs {
   }
 
   @Test
-  void twoElementArray()
+  void oneElementArrayLiteral()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayLiteral(false, "String", "[ \"exquisite\" ]")),
+            emptyRecord());
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void twoElementArrayLookup()
       throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
@@ -52,7 +77,21 @@ class TestInputGeneratorBuildArrayInputs {
   }
 
   @Test
-  void zeroElementNonEmptyArray() {
+  void twoElementArrayLiteral()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(
+                inputDefinitionWithArrayLiteral(
+                    false, "String", "[ \"exquisite\", \"wonderful\" ]")),
+            emptyRecord());
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite", "wonderful"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void zeroElementNonEmptyArrayLookup() {
     assertThrows(
         ValueCoercionException.class,
         () ->
@@ -62,12 +101,35 @@ class TestInputGeneratorBuildArrayInputs {
   }
 
   @Test
-  void twoElementNonEmptyArray()
+  void zeroElementNonEmptyArrayLiteral() {
+    assertThrows(
+        ValueCoercionException.class,
+        () ->
+            InputGenerator.buildInputs(
+                List.of(inputDefinitionWithArrayLiteral(true, "String", "[]")), emptyRecord()));
+  }
+
+  @Test
+  void twoElementNonEmptyArrayLookup()
       throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithArrayFooRatingParameter(true, "String")),
             wdsRecordWithFooRating("[ \"exquisite\", \"wonderful\" ]"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite", "wonderful"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void twoElementNonEmptyArrayLiteral()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(
+                inputDefinitionWithArrayLiteral(
+                    true, "String", "[ \"exquisite\", \"wonderful\" ]")),
+            emptyRecord());
 
     Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite", "wonderful"));
     assertEquals(expected, actual);

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildArrayInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildArrayInputs.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class TestInputGeneratorBuildFileInputs {
+class TestInputGeneratorBuildArrayInputs {
 
   @Test
   void zeroElementArray()

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
@@ -1,0 +1,25 @@
+package bio.terra.cbas.runsets.inputs;
+
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithArrayFooRatingParameter;
+import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.runsets.types.CoercionException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TestInputGeneratorBuildFileInputs {
+
+  @Test
+  void oneElementArray() throws JsonProcessingException, CoercionException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayFooRatingParameter("String")),
+            wdsRecordWithFooRating("[ \"exquisite\" ]"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite"));
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
@@ -3,8 +3,10 @@ package bio.terra.cbas.runsets.inputs;
 import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithArrayFooRatingParameter;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.cbas.runsets.types.CoercionException;
+import bio.terra.cbas.runsets.types.ValueCoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
@@ -13,13 +15,56 @@ import org.junit.jupiter.api.Test;
 class TestInputGeneratorBuildFileInputs {
 
   @Test
+  void zeroElementArray() throws JsonProcessingException, CoercionException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
+            wdsRecordWithFooRating("[]"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of());
+    assertEquals(expected, actual);
+  }
+
+  @Test
   void oneElementArray() throws JsonProcessingException, CoercionException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
-            List.of(inputDefinitionWithArrayFooRatingParameter("String")),
+            List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
             wdsRecordWithFooRating("[ \"exquisite\" ]"));
 
     Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void twoElementArray() throws JsonProcessingException, CoercionException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
+            wdsRecordWithFooRating("[ \"exquisite\", \"wonderful\" ]"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite", "wonderful"));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void zeroElementNonEmptyArray() {
+    assertThrows(
+        ValueCoercionException.class,
+        () ->
+            InputGenerator.buildInputs(
+                List.of(inputDefinitionWithArrayFooRatingParameter(true, "String")),
+                wdsRecordWithFooRating("[]")));
+  }
+
+  @Test
+  void twoElementNonEmptyArray() throws JsonProcessingException, CoercionException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithArrayFooRatingParameter(true, "String")),
+            wdsRecordWithFooRating("[ \"exquisite\", \"wonderful\" ]"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", List.of("exquisite", "wonderful"));
     assertEquals(expected, actual);
   }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildFileInputs.java
@@ -5,6 +5,7 @@ import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWit
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import bio.terra.cbas.common.exceptions.WorkflowAttributesNotFoundException;
 import bio.terra.cbas.runsets.types.CoercionException;
 import bio.terra.cbas.runsets.types.ValueCoercionException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,7 +16,8 @@ import org.junit.jupiter.api.Test;
 class TestInputGeneratorBuildFileInputs {
 
   @Test
-  void zeroElementArray() throws JsonProcessingException, CoercionException {
+  void zeroElementArray()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
@@ -26,7 +28,8 @@ class TestInputGeneratorBuildFileInputs {
   }
 
   @Test
-  void oneElementArray() throws JsonProcessingException, CoercionException {
+  void oneElementArray()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
@@ -37,7 +40,8 @@ class TestInputGeneratorBuildFileInputs {
   }
 
   @Test
-  void twoElementArray() throws JsonProcessingException, CoercionException {
+  void twoElementArray()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithArrayFooRatingParameter(false, "String")),
@@ -58,7 +62,8 @@ class TestInputGeneratorBuildFileInputs {
   }
 
   @Test
-  void twoElementNonEmptyArray() throws JsonProcessingException, CoercionException {
+  void twoElementNonEmptyArray()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithArrayFooRatingParameter(true, "String")),

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
@@ -45,4 +45,21 @@ public final class StockOutputDefinitions {
 
     return objectMapper.readValue(rawOutputDefinition, new TypeReference<>() {});
   }
+
+  public static WorkflowOutputDefinition arrayOutputDefinition(
+      String outputName, String innerOutputType, String recordAttributeName) throws Exception {
+    String rawOutputDefinition =
+        """
+        {
+          "output_name":"%s",
+          "output_type": { "type": "array", "array_type": { "type": "primitive", "primitive_type": "%s" }},
+          "record_attribute":"%s"
+        }
+        """
+            .formatted(outputName, innerOutputType, recordAttributeName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(rawOutputDefinition, new TypeReference<>() {});
+  }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorArrays.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorArrays.java
@@ -1,0 +1,42 @@
+package bio.terra.cbas.runsets.outputs;
+
+import static bio.terra.cbas.runsets.outputs.StockOutputDefinitions.arrayOutputDefinition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.model.WorkflowOutputDefinition;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.databiosphere.workspacedata.model.RecordAttributes;
+import org.junit.jupiter.api.Test;
+
+class TestOutputGeneratorArrays {
+  static ObjectMapper objectMapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private static List<WorkflowOutputDefinition> optionalOutputDefinitions() throws Exception {
+    return List.of(
+        arrayOutputDefinition("myWorkflow.look_and_say", "Int", "look_and_say"),
+        arrayOutputDefinition(
+            "myWorkflow.out_empty_array", "String", "sir_not_appearing_in_this_record"));
+  }
+
+  @Test
+  void stringArrayOutputs() throws Exception {
+
+    // No output from Cromwell for 'not_out':
+    Map<String, Object> cromwellOutputs = new HashMap<>();
+    cromwellOutputs.put("myWorkflow.out_array", List.of(1, 11, 21, 1211, 111221, 312211, 13112221));
+
+    RecordAttributes actual =
+        OutputGenerator.buildOutputs(optionalOutputDefinitions(), cromwellOutputs);
+
+    RecordAttributes expected = new RecordAttributes();
+    expected.put("look_and_say", List.of(1, 11, 21, 1211, 111221, 312211, 13112221));
+    expected.put("sir_not_appearing_in_this_record", List.of());
+
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorArrays.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorArrays.java
@@ -26,15 +26,16 @@ class TestOutputGeneratorArrays {
   @Test
   void stringArrayOutputs() throws Exception {
 
-    // No output from Cromwell for 'not_out':
     Map<String, Object> cromwellOutputs = new HashMap<>();
-    cromwellOutputs.put("myWorkflow.out_array", List.of(1, 11, 21, 1211, 111221, 312211, 13112221));
+    cromwellOutputs.put(
+        "myWorkflow.look_and_say", List.of(1, 11, 21, 1211, 111221, 312211, 13112221));
+    cromwellOutputs.put("myWorkflow.out_empty_array", List.of());
 
     RecordAttributes actual =
         OutputGenerator.buildOutputs(optionalOutputDefinitions(), cromwellOutputs);
 
     RecordAttributes expected = new RecordAttributes();
-    expected.put("look_and_say", List.of(1, 11, 21, 1211, 111221, 312211, 13112221));
+    expected.put("look_and_say", List.of(1L, 11L, 21L, 1211L, 111221L, 312211L, 13112221L));
     expected.put("sir_not_appearing_in_this_record", List.of());
 
     assertEquals(expected, actual);


### PR DESCRIPTION
AC in ticket:

> - It is possible to provide a literal array value, or a WDS lookup array value in the input definition.
> - It should be possible to mark arrays as non-empty, in which case CBAS would validate that the array is not empty before sending it.
> 
> Test:
> 
> - Unit tests validating that input definition JSON can be correctly interpreted for array inputs.
> - Unit tests of coercion from WDS values into arrays
> - Unit tests of writing CbasArrays into cromwell inputs
> - Unit tests validating non-emptiness checks.