### PR TITLE
WX-831 Expose engine id in RunLog

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,6 +57,11 @@ psql -h 127.0.0.1 -U postgres -f ./common/postgres-init.sql
 
 #### Workspace Data Service (WDS)
 
+Create an empty WDS database in the PostgreSQL server you created above.
+```sql
+CREATE DATABASE wds;
+```
+
 Start a WDS container with the following command:
 
 ```
@@ -123,7 +128,7 @@ Then navigate to the Swagger: `http://localhost:8080/swagger-ui.html`
 
 1. Open the repo normally (File > New > Project From Existing Sources). Select the folder, and then select Gradle as the external model.
 2. In project structure (the folder icon with a little tetromino over it in the upper
-   right corner), make sure the project SDK is set to Java 17. If not, IntelliJ should
+   right corner), make sure the project SDK is set to Java 17 (>= 17.0.3). If not, IntelliJ should
    detect it on your system in the dropdown, otherwise click "Add JDK..." and navigate to
    the folder from the last step.
 3. Set up [google-java-format](https://github.com/google/google-java-format). We use the

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -288,6 +288,9 @@ components:
       properties:
         run_id:
           type: string
+        engine_id:
+          type: string
+          description: Identifier of the run in the execution engine
         workflow_url:
           type: string
           description: URL to the workflow script to run

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -36,6 +36,7 @@ public class RunsApiController implements RunsApi {
 
     return new RunLog()
         .runId(run.id().toString())
+        .engineId(run.engineId())
         .workflowUrl(run.runSet().method().methodUrl())
         .name(null)
         .state(CbasRunStatus.toCbasApiState(run.status()))


### PR DESCRIPTION
This enables us to query Cromwell about the status of a workflow in CBAS UI.

Also threw in a couple edits to the development setup guide, based on my recent experience.