### PR TITLE
[WM1533][WM-1555] New GET /run_sets API and updated GET /runs API to optionally return Runs for given Run Set

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -390,7 +390,7 @@ components:
         last_modified_timestamp:
           type: string
           format: date-time
-        runs_count:
+        run_count:
           type: integer
         error_count:
           type: integer
@@ -443,8 +443,11 @@ components:
       title: RunSetState
       example: RUNNING
       enum:
-        - SET_UNKNOWN_STATE
-        - SET_RUNNING
-        - SET_COMPLETE
-        - SET_ERROR
+        - UNKNOWN
+        - QUEUED
+        - RUNNING
+        - COMPLETE
+        - ERROR
+        - CANCELED
+        - CANCELING
       type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -25,6 +25,14 @@ paths:
       tags: [ runs ]
       summary: Get list of all runs
       operationId: getRuns
+      parameters:
+        - in: query
+          name: run_set_id
+          schema:
+            type: string
+          description: >
+            When specified, filters runs to only return fields within specified run set.
+          required: false
       responses:
         '200':
           $ref: '#/components/responses/GetRunResponse'

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -320,6 +320,8 @@ components:
           $ref: '#/components/schemas/RunState'
         workflow_params:
           type: string
+        workflow_outputs:
+          type: string
         submission_date:
           type: string
           format: date-time

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -56,6 +56,17 @@ paths:
           $ref: '#/components/responses/UserError'
         '500':
           $ref: '#/components/responses/ServerError'
+    get:
+      tags: [ run_sets ]
+      summary: Get list of all run sets
+      operationId: getRunSets
+      responses:
+        '200':
+          $ref: '#/components/responses/GetRunSetListResponse'
+        '400':
+          $ref: '#/components/responses/UserError'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/batch/v1/methods:
     get:
       summary: Lists known methods
@@ -97,6 +108,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/RunLogResponse'
+    GetRunSetListResponse:
+      description: Details about run sets
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RunSetListResponse'
     SystemStatusResponse:
       description: A JSON description of the subsystems and their statuses.
       content:
@@ -351,6 +368,32 @@ components:
         errors:
           type:
             string
+    RunSetListResponse:
+      type: object
+      properties:
+        run_sets:
+          type: array
+          items:
+            $ref: '#/components/schemas/RunSetDetailsResponse'
+    RunSetDetailsResponse:
+      type: object
+      properties:
+        run_set_id:
+          type: string
+        state:
+          $ref: '#/components/schemas/RunSetState'
+        record_type:
+          type: string
+        submission_timestamp:
+          type: string
+          format: date-time
+        last_modified_timestamp:
+          type: string
+          format: date-time
+        runs_count:
+          type: integer
+        error_count:
+          type: integer
     ErrorReport:
       type: object
       required: [ message, status_code, causes]

--- a/service/src/main/java/bio/terra/cbas/common/DateUtils.java
+++ b/service/src/main/java/bio/terra/cbas/common/DateUtils.java
@@ -1,0 +1,15 @@
+package bio.terra.cbas.common;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+
+public final class DateUtils {
+
+  public static Date convertToDate(OffsetDateTime submissionTimestamp) {
+    if (submissionTimestamp != null) {
+      return new Date(submissionTimestamp.toInstant().toEpochMilli());
+    }
+
+    return null;
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/common/DateUtils.java
+++ b/service/src/main/java/bio/terra/cbas/common/DateUtils.java
@@ -5,6 +5,8 @@ import java.util.Date;
 
 public final class DateUtils {
 
+  private DateUtils() {}
+
   public static Date convertToDate(OffsetDateTime submissionTimestamp) {
     if (submissionTimestamp != null) {
       return new Date(submissionTimestamp.toInstant().toEpochMilli());

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -10,6 +10,7 @@ import static bio.terra.cbas.models.CbasRunStatus.SYSTEM_ERROR;
 import static bio.terra.cbas.models.CbasRunStatus.UNKNOWN;
 
 import bio.terra.cbas.api.RunSetsApi;
+import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.common.exceptions.WorkflowAttributesNotFoundException;
 import bio.terra.cbas.config.CbasApiConfiguration;
 import bio.terra.cbas.dao.MethodDao;
@@ -17,6 +18,8 @@ import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dao.RunSetDao;
 import bio.terra.cbas.dependencies.wds.WdsService;
 import bio.terra.cbas.dependencies.wes.CromwellService;
+import bio.terra.cbas.model.RunSetDetailsResponse;
+import bio.terra.cbas.model.RunSetListResponse;
 import bio.terra.cbas.model.RunSetRequest;
 import bio.terra.cbas.model.RunSetState;
 import bio.terra.cbas.model.RunSetStateResponse;
@@ -75,6 +78,38 @@ public class RunSetsApiController implements RunSetsApi {
     this.runSetDao = runSetDao;
     this.runDao = runDao;
     this.cbasApiConfiguration = cbasApiConfiguration;
+  }
+
+  @Override
+  public ResponseEntity<RunSetListResponse> getRunSets() {
+    RunSetDetailsResponse runSetDetails1 = new RunSetDetailsResponse();
+    runSetDetails1.setRunSetId(UUID.randomUUID().toString());
+    runSetDetails1.setRecordType("FOO");
+    runSetDetails1.setRunsCount(5);
+    runSetDetails1.setErrorCount(0);
+    runSetDetails1.setState(RUNNING);
+    runSetDetails1.setLastModifiedTimestamp(DateUtils.convertToDate(OffsetDateTime.now()));
+    runSetDetails1.setSubmissionTimestamp(
+        DateUtils.convertToDate(OffsetDateTime.now().minusHours(3)));
+
+    RunSetDetailsResponse runSetDetails2 = new RunSetDetailsResponse();
+    runSetDetails2.setRunSetId(UUID.randomUUID().toString());
+    runSetDetails2.setRecordType("BAR");
+    runSetDetails2.setRunsCount(10);
+    runSetDetails2.setErrorCount(3);
+    runSetDetails2.setState(ERROR);
+    runSetDetails2.setLastModifiedTimestamp(DateUtils.convertToDate(OffsetDateTime.now()));
+    runSetDetails2.setSubmissionTimestamp(
+        DateUtils.convertToDate(OffsetDateTime.now().minusHours(1)));
+
+    List<RunSetDetailsResponse> runSetList = new ArrayList<>();
+    runSetList.add(runSetDetails1);
+    runSetList.add(runSetDetails2);
+
+    RunSetListResponse response = new RunSetListResponse();
+    response.setRunSets(runSetList);
+
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -41,6 +41,7 @@ public class RunsApiController implements RunsApi {
         .name(null)
         .state(CbasRunStatus.toCbasApiState(run.status()))
         .workflowParams(run.runSet().method().inputDefinition())
+        .workflowOutputs(run.runSet().method().outputDefinition())
         .submissionDate(convertToDate(run.submissionTimestamp()))
         .lastModifiedTimestamp(convertToDate(run.lastModifiedTimestamp()))
         .errorMessages(run.errorMessages());

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -47,9 +47,9 @@ public class RunsApiController implements RunsApi {
   }
 
   @Override
-  public ResponseEntity<RunLogResponse> getRuns() {
+  public ResponseEntity<RunLogResponse> getRuns(String runSetId) {
 
-    List<Run> queryResults = runDao.getRuns();
+    List<Run> queryResults = runDao.getRuns(runSetId);
     List<Run> updatedRunResults = smartPoller.updateRuns(queryResults);
 
     List<RunLog> responseList = updatedRunResults.stream().map(this::runToRunLog).toList();

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -1,14 +1,13 @@
 package bio.terra.cbas.controllers;
 
 import bio.terra.cbas.api.RunsApi;
+import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.model.RunLog;
 import bio.terra.cbas.model.RunLogResponse;
 import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.runsets.monitoring.SmartRunsPoller;
-import java.time.OffsetDateTime;
-import java.util.Date;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,14 +23,6 @@ public class RunsApiController implements RunsApi {
     this.smartPoller = smartPoller;
   }
 
-  private Date convertToDate(OffsetDateTime submissionTimestamp) {
-    if (submissionTimestamp != null) {
-      return new Date(submissionTimestamp.toInstant().toEpochMilli());
-    }
-
-    return null;
-  }
-
   private RunLog runToRunLog(Run run) {
 
     return new RunLog()
@@ -42,8 +33,8 @@ public class RunsApiController implements RunsApi {
         .state(CbasRunStatus.toCbasApiState(run.status()))
         .workflowParams(run.runSet().method().inputDefinition())
         .workflowOutputs(run.runSet().method().outputDefinition())
-        .submissionDate(convertToDate(run.submissionTimestamp()))
-        .lastModifiedTimestamp(convertToDate(run.lastModifiedTimestamp()))
+        .submissionDate(DateUtils.convertToDate(run.submissionTimestamp()))
+        .lastModifiedTimestamp(DateUtils.convertToDate(run.lastModifiedTimestamp()))
         .errorMessages(run.errorMessages());
   }
 

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -1,5 +1,6 @@
 package bio.terra.cbas.dao;
 
+import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.Run;
@@ -88,7 +89,16 @@ public class RunDao {
               rs.getString("output_definition"),
               rs.getString("record_type"));
 
-      RunSet runSet = new RunSet(rs.getObject("run_set_id", UUID.class), method);
+      RunSet runSet =
+          new RunSet(
+              rs.getObject("run_set_id", UUID.class),
+              method,
+              CbasRunSetStatus.fromValue(rs.getString("status")),
+              rs.getObject("submission_timestamp", OffsetDateTime.class),
+              rs.getObject("last_modified_timestamp", OffsetDateTime.class),
+              rs.getObject("last_polled_timestamp", OffsetDateTime.class),
+              rs.getInt("run_count"),
+              rs.getInt("error_count"));
 
       return new Run(
           rs.getObject("id", UUID.class),

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -31,11 +31,19 @@ public class RunDao {
         new EnumAwareBeanPropertySqlParameterSource(run));
   }
 
-  public List<Run> getRuns() {
+  public List<Run> getRuns(String runSetId) {
+    String whereClause = runSetId == null ? "" : " WHERE run.run_set_id = :runSetId";
+
+    MapSqlParameterSource source =
+        runSetId == null
+            ? new MapSqlParameterSource()
+            : new MapSqlParameterSource("runSetId", UUID.fromString(runSetId));
+
     String sql =
         "SELECT * FROM run INNER JOIN run_set ON run.run_set_id = run_set.id"
-            + " INNER JOIN method ON run_set.method_id = method.id";
-    return jdbcTemplate.query(sql, new RunMapper());
+            + " INNER JOIN method ON run_set.method_id = method.id"
+            + whereClause;
+    return jdbcTemplate.query(sql, source, new RunMapper());
   }
 
   public int updateRunStatus(UUID runId, CbasRunStatus newStatus) {

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -1,7 +1,12 @@
 package bio.terra.cbas.dao;
 
+import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.RunSet;
-import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -14,9 +19,38 @@ public class RunSetDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
+  public List<RunSet> getRunSets() {
+    String sql = "SELECT * FROM run_set INNER JOIN method ON run_set.method_id = method.id";
+    return jdbcTemplate.query(sql, new RunSetMapper());
+  }
+
   public int createRunSet(RunSet runSet) {
     return jdbcTemplate.update(
-        "insert into run_set (id, method_id, status, submission_timestamp, run_count, error_count) values (:id, :methodId, :status, :submissionTimestamp, :runCount, :errorCount)",
-        new BeanPropertySqlParameterSource(runSet));
+        "insert into run_set (id, method_id, status, submission_timestamp, last_modified_timestamp, last_polled_timestamp, run_count, error_count)"
+            + " values (:id, :methodId, :status, :submissionTimestamp, :lastModifiedTimestamp, :lastPolledTimestamp, :runCount, :errorCount)",
+        new EnumAwareBeanPropertySqlParameterSource(runSet));
+  }
+
+  public int updateStateAndRunDetails(
+      UUID runSetId, CbasRunSetStatus newStatus, Integer runCount, Integer errorCount) {
+    OffsetDateTime currentTimestamp = OffsetDateTime.now();
+    String sql =
+        "UPDATE run_set SET status = :status, last_modified_timestamp =:lastModifiedTimestamp, last_polled_timestamp = :lastPolledTimestamp, run_count = :runCount, error_count = :errorCount  WHERE id = :id";
+    return jdbcTemplate.update(
+        sql,
+        new MapSqlParameterSource(
+            Map.of(
+                "id",
+                runSetId,
+                "status",
+                newStatus.toString(),
+                "lastModifiedTimestamp",
+                currentTimestamp,
+                "lastPolledTimestamp",
+                currentTimestamp,
+                "runCount",
+                runCount,
+                "errorCount",
+                errorCount)));
   }
 }

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -16,7 +16,7 @@ public class RunSetDao {
 
   public int createRunSet(RunSet runSet) {
     return jdbcTemplate.update(
-        "insert into run_set (id, method_id) values (:id, :methodId)",
+        "insert into run_set (id, method_id, status, submission_timestamp, run_count, error_count) values (:id, :methodId, :status, :submissionTimestamp, :runCount, :errorCount)",
         new BeanPropertySqlParameterSource(runSet));
   }
 }

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetMapper.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetMapper.java
@@ -1,0 +1,34 @@
+package bio.terra.cbas.dao;
+
+import bio.terra.cbas.models.CbasRunSetStatus;
+import bio.terra.cbas.models.Method;
+import bio.terra.cbas.models.RunSet;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.jdbc.core.RowMapper;
+
+public class RunSetMapper implements RowMapper<RunSet> {
+
+  @Override
+  public RunSet mapRow(ResultSet rs, int rowNum) throws SQLException {
+    Method method =
+        new Method(
+            rs.getObject("method_id", UUID.class),
+            rs.getString("method_url"),
+            rs.getString("input_definition"),
+            rs.getString("output_definition"),
+            rs.getString("record_type"));
+
+    return new RunSet(
+        rs.getObject("id", UUID.class),
+        method,
+        CbasRunSetStatus.fromValue(rs.getString("status")),
+        rs.getObject("submission_timestamp", OffsetDateTime.class),
+        rs.getObject("last_modified_timestamp", OffsetDateTime.class),
+        rs.getObject("last_polled_timestamp", OffsetDateTime.class),
+        rs.getInt("run_count"),
+        rs.getInt("error_count"));
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
+++ b/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
@@ -1,0 +1,38 @@
+package bio.terra.cbas.models;
+
+import bio.terra.cbas.model.RunSetState;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum CbasRunSetStatus {
+  UNKNOWN("UNKNOWN"),
+  QUEUED("QUEUED"),
+  RUNNING("RUNNING"),
+  COMPLETE("COMPLETE"),
+  ERROR("ERROR"),
+  CANCELED("CANCELED"),
+  CANCELING("CANCELING");
+
+  private final String value;
+
+  CbasRunSetStatus(String value) {
+    this.value = value;
+  }
+
+  @JsonCreator
+  public static CbasRunSetStatus fromValue(String text) {
+    for (CbasRunSetStatus b : CbasRunSetStatus.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    return null;
+  }
+
+  public static CbasRunSetStatus fromValue(RunSetState runSetState) {
+    return fromValue(runSetState.toString());
+  }
+
+  public static RunSetState toCbasRunSetApiState(CbasRunSetStatus cbasRunSetStatus) {
+    return RunSetState.fromValue(cbasRunSetStatus.toString());
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/models/RunSet.java
+++ b/service/src/main/java/bio/terra/cbas/models/RunSet.java
@@ -1,8 +1,17 @@
 package bio.terra.cbas.models;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
-public record RunSet(UUID id, Method method) {
+public record RunSet(
+    UUID id,
+    Method method,
+    CbasRunSetStatus status,
+    OffsetDateTime submissionTimestamp,
+    OffsetDateTime lastModifiedTimestamp,
+    OffsetDateTime lastPolledTimestamp,
+    Integer runCount,
+    Integer errorCount) {
 
   public UUID getMethodId() {
     return method.id();

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasString.java
@@ -20,7 +20,11 @@ public class CbasString implements CbasValue {
     return 0L;
   }
 
-  public static CbasString parse(Object value) {
-    return new CbasString(value.toString());
+  public static CbasString parse(Object value) throws TypeCoercionException {
+    if (value instanceof String str) {
+      return new CbasString(str);
+    } else {
+      throw new TypeCoercionException(value, "String");
+    }
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/TypeCoercionException.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/TypeCoercionException.java
@@ -7,6 +7,8 @@ public class TypeCoercionException extends CoercionException {
 
   public TypeCoercionException(Object badValue, String toType) {
     super(
-        toType, badValue.getClass().getSimpleName(), "Coercion not supported between these types.");
+        badValue == null ? "null" : badValue.getClass().getSimpleName(),
+        toType,
+        "Coercion not supported between these types.");
   }
 }

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: changesets/20220823_run.yaml
       relativeToChangelogFile: true
+  - include:
+     file: changesets/20221115_add_run_set_columns.yaml
+     relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20221115_add_run_set_columns.yaml
+++ b/service/src/main/resources/changelog/changesets/20221115_add_run_set_columns.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: "1"
+      author: kpierre
+      changes:
+        - addColumn:
+            tableName: run_set
+            columns:
+              - column:
+                  name: status
+                  type: varchar(20)
+                  defaultValue: "UNKNOWN"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: submission_timestamp
+                  type: timestamp
+                  defaultValueComputed: "CURRENT_TIMESTAMP"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_modified_timestamp
+                  type: timestamp
+                  defaultValueComputed: "CURRENT_TIMESTAMP"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_polled_timestamp
+                  type: timestamp
+                  defaultValueComputed: "CURRENT_TIMESTAMP"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: run_count
+                  type: int
+                  constraints:
+                    nullable: true
+              - column:
+                  name: error_count
+                  type: int
+                  constraints:
+                    nullable: true

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -51,6 +51,7 @@ class TestRunsApiController {
   @Autowired private ObjectMapper objectMapper;
 
   private static final UUID returnedRunId = UUID.randomUUID();
+  private static final UUID runSetId = UUID.randomUUID();
   private static final UUID returnedRunEngineId = UUID.randomUUID();
   private static final String returnedEntityId = UUID.randomUUID().toString();
   private static final OffsetDateTime returnedSubmittedTime = OffsetDateTime.now();
@@ -60,7 +61,7 @@ class TestRunsApiController {
 
   private static final RunSet returnedRunSet =
       new RunSet(
-          UUID.randomUUID(),
+          runSetId,
           new Method(
               UUID.randomUUID(), "methodurl", "inputdefinition", "outputDefinition", "entitytype"),
           CbasRunSetStatus.UNKNOWN,
@@ -97,11 +98,15 @@ class TestRunsApiController {
   @Test
   void smartPollAndUpdateStatus() throws Exception {
 
-    when(runDao.getRuns(null)).thenReturn(List.of(returnedRun));
+    when(runDao.getRuns(runSetId.toString())).thenReturn(List.of(returnedRun));
 
     when(smartRunsPoller.updateRuns(eq(List.of(returnedRun)))).thenReturn(List.of(updatedRun));
 
-    MvcResult result = mockMvc.perform(get(API)).andExpect(status().isOk()).andReturn();
+    MvcResult result =
+        mockMvc
+            .perform(get(API).param("run_set_id", runSetId.toString()))
+            .andExpect(status().isOk())
+            .andReturn();
 
     verify(smartRunsPoller).updateRuns(List.of(returnedRun));
 

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.cbas.dao.RunDao;
+import bio.terra.cbas.model.RunLog;
 import bio.terra.cbas.model.RunLogResponse;
 import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.CbasRunStatus;
@@ -108,7 +109,13 @@ class TestRunsApiController {
         objectMapper.readValue(result.getResponse().getContentAsString(), RunLogResponse.class);
 
     assertEquals(1, parsedResponse.getRuns().size());
-    assertEquals(returnedRunId.toString(), parsedResponse.getRuns().get(0).getRunId());
+
+    RunLog runLog = parsedResponse.getRuns().get(0);
+
+    assertEquals(returnedRunId.toString(), runLog.getRunId());
+    assertEquals("methodurl", runLog.getWorkflowUrl());
+    assertEquals("inputdefinition", runLog.getWorkflowParams());
+    assertEquals("outputDefinition", runLog.getWorkflowOutputs());
     assertEquals(
         CbasRunStatus.toCbasApiState(COMPLETE), parsedResponse.getRuns().get(0).getState());
   }

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -89,7 +89,7 @@ class TestRunsApiController {
   @Test
   void smartPollAndUpdateStatus() throws Exception {
 
-    when(runDao.getRuns()).thenReturn(List.of(returnedRun));
+    when(runDao.getRuns(null)).thenReturn(List.of(returnedRun));
 
     when(smartRunsPoller.updateRuns(eq(List.of(returnedRun)))).thenReturn(List.of(updatedRun));
 

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.model.RunLogResponse;
+import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.Run;
@@ -60,7 +61,13 @@ class TestRunsApiController {
       new RunSet(
           UUID.randomUUID(),
           new Method(
-              UUID.randomUUID(), "methodurl", "inputdefinition", "outputDefinition", "entitytype"));
+              UUID.randomUUID(), "methodurl", "inputdefinition", "outputDefinition", "entitytype"),
+          CbasRunSetStatus.UNKNOWN,
+          returnedSubmittedTime,
+          returnedSubmittedTime,
+          returnedSubmittedTime,
+          0,
+          0);
 
   private static final Run returnedRun =
       new Run(

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPoller.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPoller.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dependencies.wds.WdsService;
 import bio.terra.cbas.dependencies.wes.CromwellService;
+import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
@@ -91,7 +92,13 @@ public class TestSmartRunsPoller {
       new RunSet(
           UUID.randomUUID(),
           new Method(
-              UUID.randomUUID(), "methodurl", "inputdefinition", outputDefinition, "entitytype"));
+              UUID.randomUUID(), "methodurl", "inputdefinition", outputDefinition, "entitytype"),
+          CbasRunSetStatus.UNKNOWN,
+          runSubmittedTime,
+          runSubmittedTime,
+          runSubmittedTime,
+          0,
+          0);
 
   final Run runToUpdate1 =
       new Run(
@@ -381,7 +388,13 @@ public class TestSmartRunsPoller {
         new RunSet(
             UUID.randomUUID(),
             new Method(
-                UUID.randomUUID(), "methodurl", "inputdefinition", outputDefinition, "entitytype"));
+                UUID.randomUUID(), "methodurl", "inputdefinition", outputDefinition, "entitytype"),
+            CbasRunSetStatus.UNKNOWN,
+            runSubmittedTime,
+            runSubmittedTime,
+            runSubmittedTime,
+            0,
+            0);
 
     Run run =
         new Run(


### PR DESCRIPTION
This PR:
- adds a new API GET /run_sets that returns details of all Run Sets in a list form
- updates API GET /runs to optionally take in a run_set_id parameter to return Runs for that particular Run Set

Closes https://broadworkbench.atlassian.net/browse/WM-1533 and https://broadworkbench.atlassian.net/browse/WM-1555