### PR TITLE
[WM-1461] Store timezone information in timestamps in db and generate time in UTC

### DIFF
--- a/service/src/main/java/bio/terra/cbas/common/DateUtils.java
+++ b/service/src/main/java/bio/terra/cbas/common/DateUtils.java
@@ -9,7 +9,25 @@ public final class DateUtils {
 
   public static Date convertToDate(OffsetDateTime submissionTimestamp) {
     if (submissionTimestamp != null) {
-      return new Date(submissionTimestamp.toInstant().toEpochMilli());
+      //      System.out.println("###### Offset timestamp: %s".formatted(submissionTimestamp));
+      //
+      //      ZonedDateTime offsetTime =
+      //          OffsetDateTime.parse(submissionTimestamp.toString()).toZonedDateTime();
+      //
+      //      System.out.println("###### Zoned timestamp: %s".formatted(offsetTime));
+      //
+      //      ZoneOffset offsetValue = submissionTimestamp.getOffset();
+      //
+      //      System.out.println("###### Zoned offset: %s".formatted(offsetValue));
+      //
+      //
+      //      System.out.println("###### Date timestamp: %s".formatted(date));
+      //
+      return Date.from(submissionTimestamp.toInstant());
+
+      //      return new Date(offsetTime.toInstant().toEpochMilli());
+
+      //      return new Date(submissionTimestamp.toInstant().toEpochMilli());
     }
 
     return null;

--- a/service/src/main/java/bio/terra/cbas/common/DateUtils.java
+++ b/service/src/main/java/bio/terra/cbas/common/DateUtils.java
@@ -1,11 +1,17 @@
 package bio.terra.cbas.common;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 
 public final class DateUtils {
 
   private DateUtils() {}
+
+  // helper function to ensure that all timestamps stored in database are in UTC
+  public static OffsetDateTime currentTimeInUTC() {
+    return OffsetDateTime.now(ZoneOffset.UTC);
+  }
 
   public static Date convertToDate(OffsetDateTime submissionTimestamp) {
     if (submissionTimestamp != null) {

--- a/service/src/main/java/bio/terra/cbas/common/DateUtils.java
+++ b/service/src/main/java/bio/terra/cbas/common/DateUtils.java
@@ -9,25 +9,7 @@ public final class DateUtils {
 
   public static Date convertToDate(OffsetDateTime submissionTimestamp) {
     if (submissionTimestamp != null) {
-      //      System.out.println("###### Offset timestamp: %s".formatted(submissionTimestamp));
-      //
-      //      ZonedDateTime offsetTime =
-      //          OffsetDateTime.parse(submissionTimestamp.toString()).toZonedDateTime();
-      //
-      //      System.out.println("###### Zoned timestamp: %s".formatted(offsetTime));
-      //
-      //      ZoneOffset offsetValue = submissionTimestamp.getOffset();
-      //
-      //      System.out.println("###### Zoned offset: %s".formatted(offsetValue));
-      //
-      //
-      //      System.out.println("###### Date timestamp: %s".formatted(date));
-      //
-      return Date.from(submissionTimestamp.toInstant());
-
-      //      return new Date(offsetTime.toInstant().toEpochMilli());
-
-      //      return new Date(submissionTimestamp.toInstant().toEpochMilli());
+      return new Date(submissionTimestamp.toInstant().toEpochMilli());
     }
 
     return null;

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import cromwell.client.model.RunId;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -153,9 +152,9 @@ public class RunSetsApiController implements RunSetsApi {
             runSetId,
             method,
             CbasRunSetStatus.UNKNOWN,
-            OffsetDateTime.now(),
-            OffsetDateTime.now(),
-            OffsetDateTime.now(),
+            DateUtils.currentTimeInUTC(),
+            DateUtils.currentTimeInUTC(),
+            DateUtils.currentTimeInUTC(),
             0,
             0);
     runSetDao.createRunSet(runSet);
@@ -307,10 +306,10 @@ public class RunSetsApiController implements RunSetsApi {
                 externalId,
                 runSet,
                 recordId,
-                OffsetDateTime.now(),
+                DateUtils.currentTimeInUTC(),
                 runState,
-                OffsetDateTime.now(),
-                OffsetDateTime.now(),
+                DateUtils.currentTimeInUTC(),
+                DateUtils.currentTimeInUTC(),
                 errors));
 
     if (created != 1) {

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -50,7 +50,7 @@ public class RunDao {
   public int updateRunStatus(UUID runId, CbasRunStatus newStatus) {
     OffsetDateTime currentTimestamp = OffsetDateTime.now();
     String sql =
-        "UPDATE run SET status = :status, last_modified_timestamp =:lastModifiedTimestamp, last_polled_timestamp = :lastPolledTimestamp  WHERE id = :id";
+        "UPDATE run SET status = :status, last_modified_timestamp =:last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp  WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(
@@ -66,7 +66,7 @@ public class RunDao {
   }
 
   public int updateLastPolledTimestamp(UUID runID) {
-    String sql = "UPDATE run SET last_polled_timestamp = :lastPolledTimestamp  WHERE id = :id";
+    String sql = "UPDATE run SET last_polled_timestamp = :last_polled_timestamp  WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(
@@ -74,7 +74,7 @@ public class RunDao {
   }
 
   public int updateErrorMessage(UUID runId, String updatedErrorMessage) {
-    String sql = "UPDATE run SET error_messages = :errorMessages WHERE id = :id";
+    String sql = "UPDATE run SET error_messages = :error_messages WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -1,5 +1,6 @@
 package bio.terra.cbas.dao;
 
+import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Method;
@@ -48,7 +49,7 @@ public class RunDao {
   }
 
   public int updateRunStatus(UUID runId, CbasRunStatus newStatus) {
-    OffsetDateTime currentTimestamp = OffsetDateTime.now();
+    OffsetDateTime currentTimestamp = DateUtils.currentTimeInUTC();
     String sql =
         "UPDATE run SET status = :status, last_modified_timestamp = :last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp WHERE id = :id";
     return jdbcTemplate.update(
@@ -70,7 +71,8 @@ public class RunDao {
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(
-            Map.of(Run.ID_COL, runID, Run.LAST_POLLED_TIMESTAMP_COL, OffsetDateTime.now())));
+            Map.of(
+                Run.ID_COL, runID, Run.LAST_POLLED_TIMESTAMP_COL, DateUtils.currentTimeInUTC())));
   }
 
   public int updateErrorMessage(UUID runId, String updatedErrorMessage) {

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -50,7 +50,7 @@ public class RunDao {
   public int updateRunStatus(UUID runId, CbasRunStatus newStatus) {
     OffsetDateTime currentTimestamp = OffsetDateTime.now();
     String sql =
-        "UPDATE run SET status = :status, last_modified_timestamp =:last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp  WHERE id = :id";
+        "UPDATE run SET status = :status, last_modified_timestamp = :last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(
@@ -66,7 +66,7 @@ public class RunDao {
   }
 
   public int updateLastPolledTimestamp(UUID runID) {
-    String sql = "UPDATE run SET last_polled_timestamp = :last_polled_timestamp  WHERE id = :id";
+    String sql = "UPDATE run SET last_polled_timestamp = :last_polled_timestamp WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -89,7 +89,7 @@ public class RunDao {
               rs.getString(Method.METHOD_URL_COL),
               rs.getString(Method.INPUT_DEFINITION_COL),
               rs.getString(Method.OUTPUT_DEFINITION_COL),
-              rs.getString(Method.OUTPUT_DEFINITION_COL));
+              rs.getString(Method.RECORD_TYPE_COL));
 
       RunSet runSet =
           new RunSet(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -1,5 +1,6 @@
 package bio.terra.cbas.dao;
 
+import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
@@ -33,7 +34,7 @@ public class RunSetDao {
 
   public int updateStateAndRunDetails(
       UUID runSetId, CbasRunSetStatus newStatus, Integer runCount, Integer errorCount) {
-    OffsetDateTime currentTimestamp = OffsetDateTime.now();
+    OffsetDateTime currentTimestamp = DateUtils.currentTimeInUTC();
     String sql =
         "UPDATE run_set SET status = :status, last_modified_timestamp = :last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp, run_count = :run_count, error_count = :error_count WHERE id = :id";
     return jdbcTemplate.update(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -35,7 +35,7 @@ public class RunSetDao {
       UUID runSetId, CbasRunSetStatus newStatus, Integer runCount, Integer errorCount) {
     OffsetDateTime currentTimestamp = OffsetDateTime.now();
     String sql =
-        "UPDATE run_set SET status = :status, last_modified_timestamp =:last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp, run_count = :run_count, error_count = :error_count  WHERE id = :id";
+        "UPDATE run_set SET status = :status, last_modified_timestamp = :last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp, run_count = :run_count, error_count = :error_count WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -35,7 +35,7 @@ public class RunSetDao {
       UUID runSetId, CbasRunSetStatus newStatus, Integer runCount, Integer errorCount) {
     OffsetDateTime currentTimestamp = OffsetDateTime.now();
     String sql =
-        "UPDATE run_set SET status = :status, last_modified_timestamp =:lastModifiedTimestamp, last_polled_timestamp = :lastPolledTimestamp, run_count = :runCount, error_count = :errorCount  WHERE id = :id";
+        "UPDATE run_set SET status = :status, last_modified_timestamp =:last_modified_timestamp, last_polled_timestamp = :last_polled_timestamp, run_count = :run_count, error_count = :error_count  WHERE id = :id";
     return jdbcTemplate.update(
         sql,
         new MapSqlParameterSource(

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
      file: changesets/20221115_add_run_set_columns.yaml
      relativeToChangelogFile: true
+  - include:
+      file: changesets/20221122_store_timezone_in_timestamps.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20221122_store_timezone_in_timestamps.yaml
+++ b/service/src/main/resources/changelog/changesets/20221122_store_timezone_in_timestamps.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: "store-timezone-in-timestamps"
+      author: sshah
+      changes:
+      - modifyDataType:
+          columnName: submission_timestamp
+          newDataType: timestamp with time zone
+          tableName: run
+      - modifyDataType:
+          columnName: last_modified_timestamp
+          newDataType: timestamp with time zone
+          tableName: run
+      - modifyDataType:
+          columnName: last_polled_timestamp
+          newDataType: timestamp with time zone
+          tableName: run
+      - modifyDataType:
+          columnName: submission_timestamp
+          newDataType: timestamp with time zone
+          tableName: run_set
+      - modifyDataType:
+          columnName: last_modified_timestamp
+          newDataType: timestamp with time zone
+          tableName: run_set
+      - modifyDataType:
+          columnName: last_polled_timestamp
+          newDataType: timestamp with time zone
+          tableName: run_set


### PR DESCRIPTION
The timestamps in database are stored with timezone information. The timestamps are passed to database in UTC time, and postgres for `timestamp with time zone` data type stores the timestamps internally in UTC format but when displayed converts the timestamp to local time ([reference](https://www.postgresql.org/docs/current/datatype-datetime.html#AEN5811)) and hence in database terminal it is displayed with offset. API responses have timestamps in UTC time and as a result the UI is able to correctly display timestamp based on the browser's timezone.

Previously
Submission created: ~ 5:09 PM EST
Value stored in DB: 2022-09-21 17:09:18.911989
Value returned in API response: 2022-09-21T17:09:18.911+00:00
Value shown in UI: 1:09 pm

Now,
Submission created: ~ 2:54PM EST
Value passed to DB: 2022-11-23T19:54:35.390733Z
Value stored in DB: 2022-11-23 14:54:35.390733-05
Value returned in API response (UTC timezone): 2022-11-23T19:54:35.390+00:00
Value shown in UI: 2:54 pm

![Screen Shot 2022-11-23 at 3 03 11 PM](https://user-images.githubusercontent.com/16748522/203636505-d7dca8f9-120a-4909-bd47-b3219d4219a9.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1461