### PR TITLE
WM-1534: Implement naive RunSet smart polling

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -42,6 +42,7 @@ paths:
           name: run_set_id
           schema:
             type: string
+            format: uuid
           description: >
             When specified, filters runs to only return fields within specified run set.
           required: false

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -9,6 +9,7 @@ import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.runsets.monitoring.SmartRunsPoller;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -41,9 +42,9 @@ public class RunsApiController implements RunsApi {
   }
 
   @Override
-  public ResponseEntity<RunLogResponse> getRuns(String runSetId) {
+  public ResponseEntity<RunLogResponse> getRuns(UUID runSetId) {
 
-    List<Run> queryResults = runDao.getRuns(runSetId);
+    List<Run> queryResults = runDao.getRuns(new RunDao.RunsFilters(runSetId, null));
     List<Run> updatedRunResults = smartPoller.updateRuns(queryResults);
 
     List<RunLog> responseList = updatedRunResults.stream().map(this::runToRunLog).toList();

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -25,6 +25,14 @@ public class RunSetDao {
     return jdbcTemplate.query(sql, new RunSetMapper());
   }
 
+  public RunSet getRunSet(UUID runSetId) {
+    String sql =
+        "SELECT * FROM run_set INNER JOIN method ON run_set.method_id = method.method_id WHERE run_set_id = :runSetId";
+    return jdbcTemplate
+        .query(sql, new MapSqlParameterSource("runSetId", runSetId), new RunSetMapper())
+        .get(0);
+  }
+
   public int createRunSet(RunSet runSet) {
     return jdbcTemplate.update(
         "insert into run_set (run_set_id, method_id, run_set_name, run_set_description, is_template, status, submission_timestamp, last_modified_timestamp, last_polled_timestamp, run_count, error_count, input_definition, output_definition, record_type)"

--- a/service/src/main/java/bio/terra/cbas/dao/util/WhereClause.java
+++ b/service/src/main/java/bio/terra/cbas/dao/util/WhereClause.java
@@ -1,0 +1,15 @@
+package bio.terra.cbas.dao.util;
+
+import java.util.List;
+import java.util.Map;
+
+public record WhereClause(List<String> conditions, Map<String, ?> params) {
+  @Override
+  public String toString() {
+    if (conditions.isEmpty()) {
+      return "";
+    } else {
+      return "WHERE (" + String.join(") AND (", conditions) + ")";
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
+++ b/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
@@ -1,7 +1,12 @@
 package bio.terra.cbas.models;
 
 import bio.terra.cbas.model.RunSetState;
+import bio.terra.cbas.util.Pair;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public enum CbasRunSetStatus {
   UNKNOWN("UNKNOWN"),
@@ -14,8 +19,21 @@ public enum CbasRunSetStatus {
 
   private final String value;
 
+  public static final Set<CbasRunSetStatus> TERMINAL_STATES = EnumSet.of(CANCELED, COMPLETE, ERROR);
+
+  public static final Set<CbasRunSetStatus> NON_TERMINAL_STATES =
+      EnumSet.of(UNKNOWN, QUEUED, RUNNING, CANCELING);
+
   CbasRunSetStatus(String value) {
     this.value = value;
+  }
+
+  public boolean isTerminal() {
+    return TERMINAL_STATES.contains(this);
+  }
+
+  public boolean nonTerminal() {
+    return !isTerminal();
   }
 
   @JsonCreator
@@ -34,5 +52,30 @@ public enum CbasRunSetStatus {
 
   public static RunSetState toCbasRunSetApiState(CbasRunSetStatus cbasRunSetStatus) {
     return RunSetState.fromValue(cbasRunSetStatus.toString());
+  }
+
+  public static CbasRunSetStatus fromRunStatuses(Map<CbasRunStatus, Integer> runStatusCounts) {
+
+    // Prefer list of pairs over Map because it guarantees the right ordering:
+    List<Pair<CbasRunStatus, CbasRunSetStatus>> statusMapping =
+        List.of(
+            new Pair<>(CbasRunStatus.UNKNOWN, CbasRunSetStatus.UNKNOWN),
+            new Pair<>(CbasRunStatus.CANCELING, CbasRunSetStatus.CANCELING),
+            new Pair<>(CbasRunStatus.RUNNING, CbasRunSetStatus.RUNNING),
+            new Pair<>(CbasRunStatus.QUEUED, CbasRunSetStatus.RUNNING),
+            new Pair<>(CbasRunStatus.PAUSED, CbasRunSetStatus.RUNNING),
+            new Pair<>(CbasRunStatus.INITIALIZING, CbasRunSetStatus.RUNNING),
+            new Pair<>(CbasRunStatus.SYSTEM_ERROR, CbasRunSetStatus.ERROR),
+            new Pair<>(CbasRunStatus.EXECUTOR_ERROR, CbasRunSetStatus.ERROR),
+            new Pair<>(CbasRunStatus.CANCELED, CbasRunSetStatus.CANCELED));
+
+    for (Pair<CbasRunStatus, CbasRunSetStatus> p : statusMapping) {
+      if (runStatusCounts.getOrDefault(p.a(), 0) != 0) {
+        return p.b();
+      }
+    }
+
+    // Nothing else matching, so the status is complete:
+    return CbasRunSetStatus.COMPLETE;
   }
 }

--- a/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
+++ b/service/src/main/java/bio/terra/cbas/models/CbasRunSetStatus.java
@@ -65,9 +65,9 @@ public enum CbasRunSetStatus {
             new Pair<>(CbasRunStatus.QUEUED, CbasRunSetStatus.RUNNING),
             new Pair<>(CbasRunStatus.PAUSED, CbasRunSetStatus.RUNNING),
             new Pair<>(CbasRunStatus.INITIALIZING, CbasRunSetStatus.RUNNING),
+            new Pair<>(CbasRunStatus.CANCELED, CbasRunSetStatus.CANCELED),
             new Pair<>(CbasRunStatus.SYSTEM_ERROR, CbasRunSetStatus.ERROR),
-            new Pair<>(CbasRunStatus.EXECUTOR_ERROR, CbasRunSetStatus.ERROR),
-            new Pair<>(CbasRunStatus.CANCELED, CbasRunSetStatus.CANCELED));
+            new Pair<>(CbasRunStatus.EXECUTOR_ERROR, CbasRunSetStatus.ERROR));
 
     for (Pair<CbasRunStatus, CbasRunSetStatus> p : statusMapping) {
       if (runStatusCounts.getOrDefault(p.a(), 0) != 0) {

--- a/service/src/main/java/bio/terra/cbas/models/CbasRunStatus.java
+++ b/service/src/main/java/bio/terra/cbas/models/CbasRunStatus.java
@@ -19,8 +19,11 @@ public enum CbasRunStatus {
   CANCELED("CANCELED"),
   CANCELING("CANCELING");
 
-  private static final Set<CbasRunStatus> TERMINAL_STATES =
+  public static final Set<CbasRunStatus> TERMINAL_STATES =
       EnumSet.of(CANCELED, COMPLETE, EXECUTOR_ERROR, SYSTEM_ERROR);
+
+  public static final Set<CbasRunStatus> NON_TERMINAL_STATES =
+      EnumSet.of(UNKNOWN, QUEUED, INITIALIZING, RUNNING, PAUSED, CANCELING);
 
   private static final Set<CbasRunStatus> ERROR_STATES = EnumSet.of(EXECUTOR_ERROR, SYSTEM_ERROR);
 

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunSetsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunSetsPoller.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,8 +19,6 @@ public class SmartRunSetsPoller {
   private final SmartRunsPoller smartRunsPoller;
   private final RunDao runDao;
   private final RunSetDao runSetDao;
-
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SmartRunSetsPoller.class);
 
   public SmartRunSetsPoller(SmartRunsPoller smartRunsPoller, RunSetDao runSetDao, RunDao runDao) {
     this.runDao = runDao;

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunSetsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunSetsPoller.java
@@ -1,0 +1,75 @@
+package bio.terra.cbas.runsets.monitoring;
+
+import bio.terra.cbas.dao.RunDao;
+import bio.terra.cbas.dao.RunSetDao;
+import bio.terra.cbas.models.CbasRunSetStatus;
+import bio.terra.cbas.models.CbasRunStatus;
+import bio.terra.cbas.models.Run;
+import bio.terra.cbas.models.RunSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmartRunSetsPoller {
+
+  private final SmartRunsPoller smartRunsPoller;
+  private final RunDao runDao;
+  private final RunSetDao runSetDao;
+
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SmartRunSetsPoller.class);
+
+  public SmartRunSetsPoller(SmartRunsPoller smartRunsPoller, RunSetDao runSetDao, RunDao runDao) {
+    this.runDao = runDao;
+    this.runSetDao = runSetDao;
+    this.smartRunsPoller = smartRunsPoller;
+  }
+
+  public List<RunSet> updateRunSets(List<RunSet> runSets) {
+    var dividedByUpdateNeeded =
+        runSets.stream().collect(Collectors.partitioningBy(r -> r.status().nonTerminal()));
+
+    return Stream.concat(
+            dividedByUpdateNeeded.get(false).stream(),
+            dividedByUpdateNeeded.get(true).stream().map(this::updateRunSet))
+        .toList();
+  }
+
+  private RunSet updateRunSet(RunSet rs) {
+    List<Run> updateableRuns =
+        runDao.getRuns(new RunDao.RunsFilters(rs.runSetId(), CbasRunStatus.NON_TERMINAL_STATES));
+
+    smartRunsPoller.updateRuns(updateableRuns);
+
+    StatusAndCounts newStatusAndCounts = newStatusAndErrorCounts(rs);
+    if (newStatusAndCounts.status != rs.status()
+        || !Objects.equals(newStatusAndCounts.runErrors, rs.errorCount())
+        || !Objects.equals(newStatusAndCounts.totalRuns, rs.runCount())) {
+      // Update and re-fetch:
+      runSetDao.updateStateAndRunDetails(
+          rs.runSetId(),
+          newStatusAndCounts.status(),
+          newStatusAndCounts.totalRuns(),
+          newStatusAndCounts.runErrors());
+      return runSetDao.getRunSet(rs.runSetId());
+    } else {
+      return rs;
+    }
+  }
+
+  private record StatusAndCounts(CbasRunSetStatus status, Integer totalRuns, Integer runErrors) {}
+
+  private StatusAndCounts newStatusAndErrorCounts(RunSet rs) {
+    Map<CbasRunStatus, Integer> runStatusCounts =
+        runDao.getRunStatusCounts(new RunDao.RunsFilters(rs.runSetId(), null));
+    return new StatusAndCounts(
+        CbasRunSetStatus.fromRunStatuses(runStatusCounts),
+        runStatusCounts.values().stream().mapToInt(Integer::intValue).sum(),
+        runStatusCounts.getOrDefault(CbasRunStatus.SYSTEM_ERROR, 0)
+            + runStatusCounts.getOrDefault(CbasRunStatus.EXECUTOR_ERROR, 0));
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/util/Pair.java
+++ b/service/src/main/java/bio/terra/cbas/util/Pair.java
@@ -1,0 +1,3 @@
+package bio.terra.cbas.util;
+
+public record Pair<A, B>(A a, B b) {}

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -36,6 +36,7 @@ import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
+import bio.terra.cbas.runsets.monitoring.SmartRunSetsPoller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cromwell.client.model.RunId;
 import java.time.Duration;
@@ -112,6 +113,7 @@ class TestRunSetsApiController {
   @MockBean private MethodDao methodDao;
   @MockBean private RunSetDao runSetDao;
   @MockBean private RunDao runDao;
+  @MockBean private SmartRunSetsPoller smartRunSetsPoller;
 
   // This mockMVC is what we use to test API requests and responses:
   @Autowired private MockMvc mockMvc;
@@ -335,7 +337,10 @@ class TestRunSetsApiController {
             "outputDefinition",
             "BAR");
 
-    when(runSetDao.getRunSets()).thenReturn(List.of(returnedRunSet1, returnedRunSet2));
+    List<RunSet> response = List.of(returnedRunSet1, returnedRunSet2);
+    when(runSetDao.getRunSets()).thenReturn(response);
+    // No smart updates:
+    when(smartRunSetsPoller.updateRunSets(response)).thenReturn(response);
 
     MvcResult result =
         mockMvc

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -348,7 +348,7 @@ class TestRunSetsApiController {
             .andReturn();
 
     // Make sure the runSetsPoller was indeed asked to update the runs:
-    verify(smartRunSetsPoller.updateRunSets(response));
+    verify(smartRunSetsPoller).updateRunSets(response);
 
     RunSetListResponse parsedResponse =
         objectMapper.readValue(result.getResponse().getContentAsString(), RunSetListResponse.class);

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -339,7 +339,6 @@ class TestRunSetsApiController {
 
     List<RunSet> response = List.of(returnedRunSet1, returnedRunSet2);
     when(runSetDao.getRunSets()).thenReturn(response);
-    // No smart updates:
     when(smartRunSetsPoller.updateRunSets(response)).thenReturn(response);
 
     MvcResult result =
@@ -347,6 +346,9 @@ class TestRunSetsApiController {
             .perform(get(API).contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn();
+
+    // Make sure the runSetsPoller was indeed asked to update the runs:
+    verify(smartRunSetsPoller.updateRunSets(response));
 
     RunSetListResponse parsedResponse =
         objectMapper.readValue(result.getResponse().getContentAsString(), RunSetListResponse.class);

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -3,6 +3,7 @@ package bio.terra.cbas.controllers;
 import static bio.terra.cbas.models.CbasRunStatus.COMPLETE;
 import static bio.terra.cbas.models.CbasRunStatus.RUNNING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -111,7 +112,7 @@ class TestRunsApiController {
   @Test
   void smartPollAndUpdateStatus() throws Exception {
 
-    when(runDao.getRuns(null)).thenReturn(List.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
 
     when(smartRunsPoller.updateRuns(eq(List.of(returnedRun)))).thenReturn(List.of(updatedRun));
 

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-public class TestRunDao {
+class TestRunDao {
 
   // Sort the NON_TERMINAL_STATES so that we can guarantee the order (based on enum ordination):
   // UNKNOWN, QUEUED, INITIALIZING, RUNNING, PAUSED, CANCELING

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -1,0 +1,112 @@
+package bio.terra.cbas.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.dao.RunDao.RunsFilters;
+import bio.terra.cbas.dao.util.WhereClause;
+import bio.terra.cbas.models.CbasRunStatus;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class TestRunDao {
+
+  // Sort the NON_TERMINAL_STATES so that we can guarantee the order (based on enum ordination):
+  // UNKNOWN, QUEUED, INITIALIZING, RUNNING, PAUSED, CANCELING
+  private static final List<CbasRunStatus> sortedNonTerminalStatuses =
+      CbasRunStatus.NON_TERMINAL_STATES.stream().sorted().toList();
+
+  @Test
+  void emptyRunFilters() {
+    RunsFilters filters = RunsFilters.empty();
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void emptyRunFilters2() {
+    RunsFilters filters = new RunsFilters(null, null);
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void emptyRunFilters3() {
+    RunsFilters filters = new RunsFilters(null, List.of());
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void runSetId() {
+    UUID uuid = UUID.randomUUID();
+    RunsFilters filters = new RunsFilters(uuid, null);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals("WHERE (run_set_id = :runSetId)", actual.toString());
+    assertEquals(Map.of("runSetId", uuid), actual.params());
+  }
+
+  @Test
+  void filterSortedNonTerminalStates() {
+
+    RunsFilters filters = new RunsFilters(null, sortedNonTerminalStatuses);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals(
+        "WHERE (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+    assertEquals(
+        Map.of(
+            "status_0", "UNKNOWN",
+            "status_1", "QUEUED",
+            "status_2", "INITIALIZING",
+            "status_3", "RUNNING",
+            "status_4", "PAUSED",
+            "status_5", "CANCELING"),
+        actual.params());
+  }
+
+  @Test
+  void filterRawNonTerminalStates() {
+
+    // Unsorted NON_TERMINAL_STATES is the more likely use case.
+    RunsFilters filters = new RunsFilters(null, CbasRunStatus.NON_TERMINAL_STATES);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals(
+        "WHERE (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+
+    // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
+    // placeholder,
+    // but we can make sure all the right keys and values are in the map in SOME order...
+    assertEquals(
+        CbasRunStatus.NON_TERMINAL_STATES.stream()
+            .map(CbasRunStatus::toString)
+            .collect(Collectors.toSet()),
+        new HashSet<>(actual.params().values()));
+    assertEquals(
+        Set.of("status_0", "status_1", "status_2", "status_3", "status_4", "status_5"),
+        actual.params().keySet());
+  }
+
+  @Test
+  void filterRunSetIdAndSortedNonTerminalStatuses() {
+    UUID uuid = UUID.randomUUID();
+    RunsFilters filters = new RunsFilters(uuid, sortedNonTerminalStatuses);
+    WhereClause actual = filters.buildWhereClause();
+
+    assertEquals(
+        "WHERE (run_set_id = :runSetId) AND (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+    assertEquals(
+        Map.of(
+            "runSetId", uuid,
+            "status_0", "UNKNOWN",
+            "status_1", "QUEUED",
+            "status_2", "INITIALIZING",
+            "status_3", "RUNNING",
+            "status_4", "PAUSED",
+            "status_5", "CANCELING"),
+        actual.params());
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -43,7 +43,7 @@ public class TestRunDao {
     UUID uuid = UUID.randomUUID();
     RunsFilters filters = new RunsFilters(uuid, null);
     WhereClause actual = filters.buildWhereClause();
-    assertEquals("WHERE (run_set_id = :runSetId)", actual.toString());
+    assertEquals("WHERE (run.run_set_id = :runSetId)", actual.toString());
     assertEquals(Map.of("runSetId", uuid), actual.params());
   }
 
@@ -53,7 +53,7 @@ public class TestRunDao {
     RunsFilters filters = new RunsFilters(null, sortedNonTerminalStatuses);
     WhereClause actual = filters.buildWhereClause();
     assertEquals(
-        "WHERE (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
         actual.toString());
     assertEquals(
         Map.of(
@@ -73,7 +73,7 @@ public class TestRunDao {
     RunsFilters filters = new RunsFilters(null, CbasRunStatus.NON_TERMINAL_STATES);
     WhereClause actual = filters.buildWhereClause();
     assertEquals(
-        "WHERE (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
         actual.toString());
 
     // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
@@ -96,7 +96,7 @@ public class TestRunDao {
     WhereClause actual = filters.buildWhereClause();
 
     assertEquals(
-        "WHERE (run_set_id = :runSetId) AND (status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        "WHERE (run.run_set_id = :runSetId) AND (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
         actual.toString());
     assertEquals(
         Map.of(

--- a/service/src/test/java/bio/terra/cbas/models/TestCbasRunSetStatus.java
+++ b/service/src/test/java/bio/terra/cbas/models/TestCbasRunSetStatus.java
@@ -1,0 +1,102 @@
+package bio.terra.cbas.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TestCbasRunSetStatus {
+
+  @Test
+  void noRuns() {
+
+    Map<CbasRunStatus, Integer> runStatuses = Map.of();
+
+    assertEquals(CbasRunSetStatus.COMPLETE, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void justRunningRuns() {
+
+    var runStatuses = Map.of(CbasRunStatus.RUNNING, 10);
+
+    assertEquals(CbasRunSetStatus.RUNNING, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void justCompletedRuns() {
+
+    var runStatuses = Map.of(CbasRunStatus.COMPLETE, 10);
+
+    assertEquals(CbasRunSetStatus.COMPLETE, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void runningAndCompletedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.RUNNING, 5,
+            CbasRunStatus.COMPLETE, 5);
+
+    assertEquals(CbasRunSetStatus.RUNNING, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void runningAndCompletedAndFailedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.RUNNING, 5,
+            CbasRunStatus.SYSTEM_ERROR, 5,
+            CbasRunStatus.COMPLETE, 5);
+
+    assertEquals(CbasRunSetStatus.RUNNING, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void completedAndFailedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.SYSTEM_ERROR, 5,
+            CbasRunStatus.COMPLETE, 5);
+
+    assertEquals(CbasRunSetStatus.ERROR, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void completedAndExecutorFailedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.EXECUTOR_ERROR, 5,
+            CbasRunStatus.COMPLETE, 5);
+
+    assertEquals(CbasRunSetStatus.ERROR, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void canceledAndCompleteAndFailedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.EXECUTOR_ERROR, 5,
+            CbasRunStatus.COMPLETE, 5,
+            CbasRunStatus.CANCELED, 5);
+
+    assertEquals(CbasRunSetStatus.CANCELED, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+
+  @Test
+  void cancelingAndCompleteAndFailedRuns() {
+
+    var runStatuses =
+        Map.of(
+            CbasRunStatus.EXECUTOR_ERROR, 5,
+            CbasRunStatus.COMPLETE, 5,
+            CbasRunStatus.CANCELING, 5);
+
+    assertEquals(CbasRunSetStatus.CANCELING, CbasRunSetStatus.fromRunStatuses(runStatuses));
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunSetsPoller.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunSetsPoller.java
@@ -1,0 +1,132 @@
+package bio.terra.cbas.runsets.monitoring;
+
+import static bio.terra.cbas.models.CbasRunStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import bio.terra.cbas.dao.RunDao;
+import bio.terra.cbas.dao.RunSetDao;
+import bio.terra.cbas.models.CbasRunSetStatus;
+import bio.terra.cbas.models.Run;
+import bio.terra.cbas.models.RunSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = SmartRunsPoller.class)
+public class TestSmartRunSetsPoller {
+
+  private SmartRunsPoller smartRunsPoller;
+  private RunDao runDao;
+  private RunSetDao runSetDao;
+
+  @BeforeEach
+  void init() {
+    smartRunsPoller = mock(SmartRunsPoller.class);
+    runDao = mock(RunDao.class);
+    runSetDao = mock(RunSetDao.class);
+  }
+
+  @Test
+  void updateRunSetToComplete() {
+    SmartRunSetsPoller smartRunSetsPoller =
+        new SmartRunSetsPoller(smartRunsPoller, runSetDao, runDao);
+
+    UUID runSetId = UUID.randomUUID();
+    RunSet runSetToUpdate =
+        new RunSet(
+            runSetId,
+            null,
+            null,
+            null,
+            false,
+            CbasRunSetStatus.RUNNING,
+            null,
+            null,
+            null,
+            2,
+            0,
+            null,
+            null,
+            null);
+
+    RunSet runSetUpdated =
+        new RunSet(
+            runSetId,
+            null,
+            null,
+            null,
+            false,
+            CbasRunSetStatus.COMPLETE,
+            null,
+            null,
+            null,
+            2,
+            0,
+            null,
+            null,
+            null);
+
+    UUID runId1 = UUID.randomUUID();
+    Run run1Incomplete =
+        new Run(runId1, null, runSetToUpdate, null, null, RUNNING, null, null, null);
+
+    Run run1Complete =
+        new Run(runId1, null, runSetToUpdate, null, null, COMPLETE, null, null, null);
+
+    UUID runId2 = UUID.randomUUID();
+    Run run2Incomplete =
+        new Run(runId2, null, runSetToUpdate, null, null, RUNNING, null, null, null);
+
+    Run run2Complete =
+        new Run(runId2, null, runSetToUpdate, null, null, COMPLETE, null, null, null);
+
+    // Set up mocks:
+
+    // Initial query of runs in the run set:
+    ArgumentCaptor<RunDao.RunsFilters> runsFiltersForGetRuns =
+        ArgumentCaptor.forClass(RunDao.RunsFilters.class);
+    when(runDao.getRuns(runsFiltersForGetRuns.capture()))
+        .thenReturn(List.of(run1Incomplete, run2Incomplete));
+
+    // When the smart runs poller is checked:
+    when(smartRunsPoller.updateRuns(List.of(run1Incomplete, run2Incomplete)))
+        .thenReturn(List.of(run1Complete, run2Complete));
+
+    // When we re-query for up-to-the-minute run status counts:
+    ArgumentCaptor<RunDao.RunsFilters> runsFiltersForGetRunStatusCounts =
+        ArgumentCaptor.forClass(RunDao.RunsFilters.class);
+    when(runDao.getRunStatusCounts(runsFiltersForGetRunStatusCounts.capture()))
+        .thenReturn(Map.of(COMPLETE, 2));
+
+    // Updating the run set with the new information:
+    when(runSetDao.updateStateAndRunDetails(runSetId, CbasRunSetStatus.COMPLETE, 2, 0))
+        .thenReturn(1);
+
+    // Re-fetching the updated run set for update:
+    when(runSetDao.getRunSet(runSetId)).thenReturn(runSetUpdated);
+
+    // Run the update:
+    var result = smartRunSetsPoller.updateRunSets(List.of(runSetToUpdate));
+
+    // Validate the results:
+    verify(runDao).getRuns(any());
+    assertEquals(runSetId, runsFiltersForGetRuns.getValue().runSetId());
+    assertEquals(NON_TERMINAL_STATES, runsFiltersForGetRuns.getValue().statuses());
+
+    verify(smartRunsPoller).updateRuns(List.of(run1Incomplete, run2Incomplete));
+
+    verify(runDao).getRunStatusCounts(any());
+    assertEquals(runSetId, runsFiltersForGetRunStatusCounts.getValue().runSetId());
+    assertNull(runsFiltersForGetRunStatusCounts.getValue().statuses());
+
+    verify(runSetDao).updateStateAndRunDetails(runSetId, CbasRunSetStatus.COMPLETE, 2, 0);
+    verify(runSetDao).getRunSet(runSetId);
+
+    assertEquals(List.of(runSetUpdated), result);
+  }
+}


### PR DESCRIPTION
"Naive" in the sense that it blocks API responses on results of updating runs in all non-terminal run sets.

We know that won't scale well, but the hope is that it scales "well enough" for public preview.