### PR TITLE
WX-864 Enable workflow logs written to storage

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
@@ -1,11 +1,12 @@
 package bio.terra.cbas.config;
 
-import cromwell.client.ApiClient;
-import cromwell.client.api.WorkflowsApi;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import cromwell.client.ApiClient;
+import cromwell.client.api.WorkflowsApi;
+
 @ConfigurationProperties(prefix = "workflow-engines.cromwell")
-public record CromwellServerConfiguration(String baseUri, String healthUri) {
+public record CromwellServerConfiguration(String baseUri, String healthUri, String finalWorkflowLogDir) {
   public WorkflowsApi workflowsApi() {
     ApiClient client = new ApiClient();
     client.setBasePath(baseUri);

--- a/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CromwellServerConfiguration.java
@@ -1,12 +1,12 @@
 package bio.terra.cbas.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import cromwell.client.ApiClient;
 import cromwell.client.api.WorkflowsApi;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "workflow-engines.cromwell")
-public record CromwellServerConfiguration(String baseUri, String healthUri, String finalWorkflowLogDir) {
+public record CromwellServerConfiguration(
+    String baseUri, String healthUri, String finalWorkflowLogDir) {
   public WorkflowsApi workflowsApi() {
     ApiClient client = new ApiClient();
     client.setBasePath(baseUri);

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
@@ -1,9 +1,12 @@
 package bio.terra.cbas.dependencies.wes;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import cromwell.client.ApiClient;
 import cromwell.client.api.Ga4GhWorkflowExecutionServiceWesAlphaPreviewApi;
-import org.springframework.stereotype.Component;
 
 @Component
 public class CromwellClient {
@@ -16,6 +19,10 @@ public class CromwellClient {
 
   private ApiClient getApiClient() {
     return new ApiClient().setBasePath(cromwellServerConfiguration.baseUri());
+  }
+
+  public Optional<String> getFinalWorkflowLogDirOption() {
+    return Optional.ofNullable(this.cromwellServerConfiguration.finalWorkflowLogDir());
   }
 
   Ga4GhWorkflowExecutionServiceWesAlphaPreviewApi wesAPI() {

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
@@ -1,12 +1,10 @@
 package bio.terra.cbas.dependencies.wes;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Component;
-
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import cromwell.client.ApiClient;
 import cromwell.client.api.Ga4GhWorkflowExecutionServiceWesAlphaPreviewApi;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
 
 @Component
 public class CromwellClient {

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
@@ -29,6 +29,9 @@ public class CromwellService {
 
   public RunId submitWorkflow(String workflowUrl, Map<String, Object> params)
       throws ApiException, JsonProcessingException {
+    
+    // TODO [WX-887]: This supplies a JSON snippet to WES to use as workflowOptions for a cromwell submission,
+    // but will require additional changes to the WesSumbission in Cromwell to use these options correctly to enable the log writing
     String workflowOptions =
         this.cromwellClient
             .getFinalWorkflowLogDirOption()

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
@@ -1,18 +1,21 @@
 package bio.terra.cbas.dependencies.wes;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.runsets.inputs.InputGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import cromwell.client.ApiException;
 import cromwell.client.model.FailureMessage;
 import cromwell.client.model.RunId;
 import cromwell.client.model.RunStatus;
 import cromwell.client.model.WorkflowMetadataResponse;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import org.springframework.stereotype.Component;
 
 @Component
 public class CromwellService {
@@ -29,11 +32,14 @@ public class CromwellService {
 
   public RunId submitWorkflow(String workflowUrl, Map<String, Object> params)
       throws ApiException, JsonProcessingException {
+    String workflowOptions = this.cromwellClient.getFinalWorkflowLogDirOption()
+        .map(dir -> String.format("{\"final_workflow_log_dir\": %s}", dir))
+        .orElse(null);
 
     return cromwellClient
         .wesAPI()
         .runWorkflow(
-            InputGenerator.inputsToJson(params), null, null, null, null, workflowUrl, null);
+            InputGenerator.inputsToJson(params), null, null, null, workflowOptions, workflowUrl, null);
   }
 
   public RunStatus runStatus(String runId) throws ApiException {

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
@@ -32,14 +32,22 @@ public class CromwellService {
 
   public RunId submitWorkflow(String workflowUrl, Map<String, Object> params)
       throws ApiException, JsonProcessingException {
-    String workflowOptions = this.cromwellClient.getFinalWorkflowLogDirOption()
-        .map(dir -> String.format("{\"final_workflow_log_dir\": %s}", dir))
-        .orElse(null);
+    String workflowOptions =
+        this.cromwellClient
+            .getFinalWorkflowLogDirOption()
+            .map(dir -> String.format("{\"final_workflow_log_dir\": %s}", dir))
+            .orElse(null);
 
     return cromwellClient
         .wesAPI()
         .runWorkflow(
-            InputGenerator.inputsToJson(params), null, null, null, workflowOptions, workflowUrl, null);
+            InputGenerator.inputsToJson(params),
+            null,
+            null,
+            null,
+            workflowOptions,
+            workflowUrl,
+            null);
   }
 
   public RunStatus runStatus(String runId) throws ApiException {

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
@@ -29,9 +29,10 @@ public class CromwellService {
 
   public RunId submitWorkflow(String workflowUrl, Map<String, Object> params)
       throws ApiException, JsonProcessingException {
-    
-    // TODO [WX-887]: This supplies a JSON snippet to WES to use as workflowOptions for a cromwell submission,
-    // but will require additional changes to the WesSumbission in Cromwell to use these options correctly to enable the log writing
+
+    // TODO [WX-887]: This supplies a JSON snippet to WES to use as workflowOptions for a cromwell
+    // submission, but will require additional changes to the WesSubmission in Cromwell to use
+    // these options correctly to enable the log writing
     String workflowOptions =
         this.cromwellClient
             .getFinalWorkflowLogDirOption()

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellService.java
@@ -1,21 +1,18 @@
 package bio.terra.cbas.dependencies.wes;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Component;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.runsets.inputs.InputGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import cromwell.client.ApiException;
 import cromwell.client.model.FailureMessage;
 import cromwell.client.model.RunId;
 import cromwell.client.model.RunStatus;
 import cromwell.client.model.WorkflowMetadataResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
 
 @Component
 public class CromwellService {


### PR DESCRIPTION
To enable workflow logs to be written to a storage container, the workflow must have a options.json that includes the option "final_workflow_log_dir". This change adds a CBAS config specifying a log directory to write to, and passes this option through the WES API. This is intended to mirror how rawls supplies this option in GCP. 

An outstanding change is required to make WES use this value for workflowOptions on submission.

There is an accompanying helm change to supply this configuration [here](https://github.com/broadinstitute/cromwhelm/pull/153)