### PR TITLE
[WM-1658] add changeset to update fetch_sra_to_bam input/output definitions

### DIFF
--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -41,3 +41,6 @@ databaseChangeLog:
   - include:
       file: changesets/20230123_remove_target_workflows.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20230124_fetch_sra_to_bam_io_updates.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
+++ b/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
@@ -1,0 +1,152 @@
+databaseChangeLog:
+  - changeSet:
+      id: "update fetch_sra_to_bam inputs/outputs to match the target workspace for public preview"
+      author: mspector
+      changes:
+        - update:
+            tableName: run_set
+            where: run_set_id='10000000-0000-0000-0000-000000000008'
+            columns:
+              - column:
+                  name: input_definition
+                  value: |
+                    [
+                      {
+                        "input_name": "SRA_ID",
+                        "input_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "source": {
+                          "type": "record_lookup",
+                          "record_attribute": "sra_id"
+                        }
+                      },
+                      {
+                        "input_name": "docker",
+                        "input_type": {
+                          "type": "optional",
+                          "optional_type": {
+                            "type": "primitive",
+                            "primitive_type": "String"
+                          }
+                        },
+                        "source": {
+                          "type": "none"
+                        }
+                      },
+                      {
+                        "input_name": "machine_mem_gb",
+                        "input_type": {
+                          "type": "optional",
+                          "optional_type": {
+                            "type": "primitive",
+                            "primitive_type": "Int"
+                          }
+                        },
+                        "source": {
+                          "type": "none"
+                        }
+                      }
+                    ]
+              - column:
+                  name: output_definition
+                  value: |
+                    [
+                      {
+                        "output_name": "sra_metadata",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "File"
+                        },
+                        "record_attribute": "sra_metadata"
+                      },
+                      {
+                        "output_name": "reads_ubam",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "File"
+                        },
+                        "record_attribute": "reads_ubam"
+                      },
+                      {
+                        "output_name": "biosample_accession",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "biosample_accession"
+                      },
+                      {
+                        "output_name": "sample_geo_loc",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sample_geo_loc"
+                      },
+                      {
+                        "output_name": "sample_collection_date",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sample_collection_date"
+                      },
+                      {
+                        "output_name": "sequencing_center",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sequencing_center"
+                      },
+                      {
+                        "output_name": "sequencing_platform",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sequencing_platform"
+                      },
+                      {
+                        "output_name": "library_id",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "library_id"
+                      },
+                      {
+                        "output_name": "run_date",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "run_date"
+                      },
+                      {
+                        "output_name": "sample_collected_by",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sample_collected_by"
+                      },
+                      {
+                        "output_name": "sample_strain",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sample_strain"
+                      },
+                      {
+                        "output_name": "sequencing_platform_model",
+                        "output_type": {
+                          "type": "primitive",
+                          "primitive_type": "String"
+                        },
+                        "record_attribute": "sequencing_platform_model"
+                      }
+                    ]

--- a/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
+++ b/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
@@ -12,7 +12,7 @@ databaseChangeLog:
                   value: |
                     [
                       {
-                        "input_name": "Fetch_SRA_to_BAM.SRA_ID",
+                        "input_name": "fetch_sra_to_bam.Fetch_SRA_to_BAM.SRA_ID",
                         "input_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -23,7 +23,7 @@ databaseChangeLog:
                         }
                       },
                       {
-                        "input_name": "Fetch_SRA_to_BAM.docker",
+                        "input_name": "fetch_sra_to_bam.Fetch_SRA_to_BAM.docker",
                         "input_type": {
                           "type": "optional",
                           "optional_type": {
@@ -36,7 +36,7 @@ databaseChangeLog:
                         }
                       },
                       {
-                        "input_name": "Fetch_SRA_to_BAM.machine_mem_gb",
+                        "input_name": "fetch_sra_to_bam.Fetch_SRA_to_BAM.machine_mem_gb",
                         "input_type": {
                           "type": "optional",
                           "optional_type": {

--- a/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
+++ b/service/src/main/resources/changelog/changesets/20230124_fetch_sra_to_bam_io_updates.yaml
@@ -12,7 +12,7 @@ databaseChangeLog:
                   value: |
                     [
                       {
-                        "input_name": "SRA_ID",
+                        "input_name": "Fetch_SRA_to_BAM.SRA_ID",
                         "input_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -23,7 +23,7 @@ databaseChangeLog:
                         }
                       },
                       {
-                        "input_name": "docker",
+                        "input_name": "Fetch_SRA_to_BAM.docker",
                         "input_type": {
                           "type": "optional",
                           "optional_type": {
@@ -36,7 +36,7 @@ databaseChangeLog:
                         }
                       },
                       {
-                        "input_name": "machine_mem_gb",
+                        "input_name": "Fetch_SRA_to_BAM.machine_mem_gb",
                         "input_type": {
                           "type": "optional",
                           "optional_type": {
@@ -54,7 +54,7 @@ databaseChangeLog:
                   value: |
                     [
                       {
-                        "output_name": "sra_metadata",
+                        "output_name": "fetch_sra_to_bam.sra_metadata",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "File"
@@ -62,7 +62,7 @@ databaseChangeLog:
                         "record_attribute": "sra_metadata"
                       },
                       {
-                        "output_name": "reads_ubam",
+                        "output_name": "fetch_sra_to_bam.reads_ubam",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "File"
@@ -70,7 +70,7 @@ databaseChangeLog:
                         "record_attribute": "reads_ubam"
                       },
                       {
-                        "output_name": "biosample_accession",
+                        "output_name": "fetch_sra_to_bam.biosample_accession",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -78,7 +78,7 @@ databaseChangeLog:
                         "record_attribute": "biosample_accession"
                       },
                       {
-                        "output_name": "sample_geo_loc",
+                        "output_name": "fetch_sra_to_bam.sample_geo_loc",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -86,7 +86,7 @@ databaseChangeLog:
                         "record_attribute": "sample_geo_loc"
                       },
                       {
-                        "output_name": "sample_collection_date",
+                        "output_name": "fetch_sra_to_bam.sample_collection_date",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -94,7 +94,7 @@ databaseChangeLog:
                         "record_attribute": "sample_collection_date"
                       },
                       {
-                        "output_name": "sequencing_center",
+                        "output_name": "fetch_sra_to_bam.sequencing_center",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -102,7 +102,7 @@ databaseChangeLog:
                         "record_attribute": "sequencing_center"
                       },
                       {
-                        "output_name": "sequencing_platform",
+                        "output_name": "fetch_sra_to_bam.sequencing_platform",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -110,7 +110,7 @@ databaseChangeLog:
                         "record_attribute": "sequencing_platform"
                       },
                       {
-                        "output_name": "library_id",
+                        "output_name": "fetch_sra_to_bam.library_id",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -118,7 +118,7 @@ databaseChangeLog:
                         "record_attribute": "library_id"
                       },
                       {
-                        "output_name": "run_date",
+                        "output_name": "fetch_sra_to_bam.run_date",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -126,7 +126,7 @@ databaseChangeLog:
                         "record_attribute": "run_date"
                       },
                       {
-                        "output_name": "sample_collected_by",
+                        "output_name": "fetch_sra_to_bam.sample_collected_by",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -134,7 +134,7 @@ databaseChangeLog:
                         "record_attribute": "sample_collected_by"
                       },
                       {
-                        "output_name": "sample_strain",
+                        "output_name": "fetch_sra_to_bam.sample_strain",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"
@@ -142,7 +142,7 @@ databaseChangeLog:
                         "record_attribute": "sample_strain"
                       },
                       {
-                        "output_name": "sequencing_platform_model",
+                        "output_name": "fetch_sra_to_bam.sequencing_platform_model",
                         "output_type": {
                           "type": "primitive",
                           "primitive_type": "String"


### PR DESCRIPTION
(this is just part of WM-1658)

Note that there is a discrepancy between the input configuration in the dev workspace vs. the data tables that Beth provided in Slack:

In the dev workspace, the variable `SRA_ID` is supplied by the attribute `accession`, but in Beth's TSV file, it's supplied by the attribute `sra_id`. This PR assumes that Beth's TSV is most accurate.