### PR TITLE
WM-1669, WM-1633, WM-1637: CBAS Map Types

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -250,7 +250,7 @@ components:
           type: string
           description: Indicates what type of parameter type definition this is.
           required: true
-          enum: [ primitive, optional, array ]
+          enum: [ primitive, optional, array, map ]
           example: record_lookup
       oneOf:
         - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'
@@ -262,6 +262,7 @@ components:
           primitive: 'ParameterTypeDefinitionPrimitive'
           optional: 'ParameterTypeDefinitionOptional'
           array: 'ParameterTypeDefinitionArray'
+          map: 'ParameterTypeDefinitionMap'
 
     PrimitiveParameterValueType:
       title: PrimitiveParameterValueType
@@ -300,6 +301,19 @@ components:
           type: boolean
           default: false
         array_type:
+          $ref: ParameterTypeDefinition
+
+    ParameterTypeDefinitionMap:
+      type: object
+      required:
+        - key_type
+        - value_type
+      allOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinition'
+      properties:
+        key_type:
+          $ref: ParameterTypeDefinition
+        value_type:
           $ref: ParameterTypeDefinition
 
     # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -256,6 +256,7 @@ components:
         - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'
         - $ref: '#/components/schemas/ParameterTypeDefinitionOptional'
         - $ref: '#/components/schemas/ParameterTypeDefinitionArray'
+        - $ref: '#/components/schemas/ParameterTypeDefinitionMap'
       discriminator:
         propertyName: "type"
         mapping:
@@ -312,7 +313,7 @@ components:
         - $ref: '#/components/schemas/ParameterTypeDefinition'
       properties:
         key_type:
-          $ref: ParameterTypeDefinition
+          $ref: PrimitiveParameterValueType
         value_type:
           $ref: ParameterTypeDefinition
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasArray.java
@@ -4,7 +4,7 @@ import bio.terra.cbas.model.ParameterTypeDefinition;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CbasArray implements CbasOptional {
+public class CbasArray implements CbasValue {
 
   private final List<CbasValue> values;
 

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasMap.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasMap.java
@@ -1,0 +1,54 @@
+package bio.terra.cbas.runsets.types;
+
+import bio.terra.cbas.model.ParameterTypeDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CbasMap implements CbasValue {
+
+  private final Map<CbasValue, CbasValue> values;
+
+  private final ParameterTypeDefinition keyType;
+  private final ParameterTypeDefinition valueType;
+
+  public CbasMap(
+      ParameterTypeDefinition keyType,
+      ParameterTypeDefinition valueType,
+      Map<CbasValue, CbasValue> values) {
+    this.values = values;
+    this.keyType = keyType;
+    this.valueType = valueType;
+  }
+
+  @Override
+  public Object asSerializableValue() {
+    return values.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                e -> e.getKey().asSerializableValue(), e -> e.getValue().asSerializableValue()));
+  }
+
+  @Override
+  public long countFiles() {
+    return values.entrySet().stream()
+        .mapToLong(e -> e.getKey().countFiles() + e.getValue().countFiles())
+        .sum();
+  }
+
+  public static CbasMap parseValue(
+      ParameterTypeDefinition keyType, ParameterTypeDefinition valueType, Object values)
+      throws CoercionException {
+    if (values instanceof Map<?, ?> valueMap) {
+      HashMap<CbasValue, CbasValue> coercedValues = new HashMap<>();
+      for (Map.Entry<?, ?> entry : valueMap.entrySet()) {
+        coercedValues.put(
+            CbasValue.parseValue(keyType, entry.getKey()),
+            CbasValue.parseValue(valueType, entry.getValue()));
+      }
+      return new CbasMap(keyType, valueType, coercedValues);
+    } else {
+      throw new TypeCoercionException(values, "Map[%s, %s]".formatted(keyType, valueType));
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasMap.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasMap.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.runsets.types;
 
 import bio.terra.cbas.model.ParameterTypeDefinition;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,11 +10,11 @@ public class CbasMap implements CbasValue {
 
   private final Map<CbasValue, CbasValue> values;
 
-  private final ParameterTypeDefinition keyType;
-  private final ParameterTypeDefinition valueType;
+  final PrimitiveParameterValueType keyType;
+  final ParameterTypeDefinition valueType;
 
   public CbasMap(
-      ParameterTypeDefinition keyType,
+      PrimitiveParameterValueType keyType,
       ParameterTypeDefinition valueType,
       Map<CbasValue, CbasValue> values) {
     this.values = values;
@@ -37,13 +38,13 @@ public class CbasMap implements CbasValue {
   }
 
   public static CbasMap parseValue(
-      ParameterTypeDefinition keyType, ParameterTypeDefinition valueType, Object values)
+      PrimitiveParameterValueType keyType, ParameterTypeDefinition valueType, Object values)
       throws CoercionException {
     if (values instanceof Map<?, ?> valueMap) {
       HashMap<CbasValue, CbasValue> coercedValues = new HashMap<>();
       for (Map.Entry<?, ?> entry : valueMap.entrySet()) {
         coercedValues.put(
-            CbasValue.parseValue(keyType, entry.getKey()),
+            CbasValue.parsePrimitive(keyType, entry.getKey()),
             CbasValue.parseValue(valueType, entry.getValue()));
       }
       return new CbasMap(keyType, valueType, coercedValues);

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -2,6 +2,7 @@ package bio.terra.cbas.runsets.types;
 
 import bio.terra.cbas.model.ParameterTypeDefinition;
 import bio.terra.cbas.model.ParameterTypeDefinitionArray;
+import bio.terra.cbas.model.ParameterTypeDefinitionMap;
 import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
 
@@ -35,6 +36,10 @@ public interface CbasValue {
     } else if (parameterType instanceof ParameterTypeDefinitionArray arrayDefinition) {
       var innerType = arrayDefinition.getArrayType();
       return CbasArray.parseValue(innerType, value, arrayDefinition.isNonEmpty());
+    } else if (parameterType instanceof ParameterTypeDefinitionMap mapDefinition) {
+      ParameterTypeDefinition keyType = mapDefinition.getKeyType();
+      ParameterTypeDefinition valueType = mapDefinition.getValueType();
+      return CbasMap.parseValue(keyType, valueType, value);
     } else {
       throw new TypeCoercionException(value, parameterType.toString());
     }

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -5,6 +5,7 @@ import bio.terra.cbas.model.ParameterTypeDefinitionArray;
 import bio.terra.cbas.model.ParameterTypeDefinitionMap;
 import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
 
 public interface CbasValue {
   Object asSerializableValue();
@@ -16,16 +17,22 @@ public interface CbasValue {
    */
   long countFiles();
 
+  static CbasValue parsePrimitive(
+      PrimitiveParameterValueType primitiveParameterValueType, Object value)
+      throws CoercionException {
+    return switch (primitiveParameterValueType) {
+      case STRING -> CbasString.parse(value);
+      case INT -> CbasInt.parse(value);
+      case BOOLEAN -> CbasBoolean.parse(value);
+      case FLOAT -> CbasFloat.parse(value);
+      case FILE -> CbasFile.parse(value);
+    };
+  }
+
   static CbasValue parseValue(ParameterTypeDefinition parameterType, Object value)
       throws CoercionException {
     if (parameterType instanceof ParameterTypeDefinitionPrimitive primitiveDefinition) {
-      return switch (primitiveDefinition.getPrimitiveType()) {
-        case STRING -> CbasString.parse(value);
-        case INT -> CbasInt.parse(value);
-        case BOOLEAN -> CbasBoolean.parse(value);
-        case FLOAT -> CbasFloat.parse(value);
-        case FILE -> CbasFile.parse(value);
-      };
+      return parsePrimitive(primitiveDefinition.getPrimitiveType(), value);
     } else if (parameterType instanceof ParameterTypeDefinitionOptional optionalDefinition) {
       if (value == null) {
         return new CbasOptionalNone();
@@ -37,7 +44,7 @@ public interface CbasValue {
       var innerType = arrayDefinition.getArrayType();
       return CbasArray.parseValue(innerType, value, arrayDefinition.isNonEmpty());
     } else if (parameterType instanceof ParameterTypeDefinitionMap mapDefinition) {
-      ParameterTypeDefinition keyType = mapDefinition.getKeyType();
+      PrimitiveParameterValueType keyType = mapDefinition.getKeyType();
       ParameterTypeDefinition valueType = mapDefinition.getValueType();
       return CbasMap.parseValue(keyType, valueType, value);
     } else {

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -106,6 +106,25 @@ public final class StockInputDefinitions {
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
 
+  public static WorkflowInputDefinition inputDefinitionWithMapFooRatingParameter(
+      String mapKeyType, String mapValueType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": { "type": "map", "key_type": { "type": "primitive", "primitive_type": "%s" }, "value_type": { "type": "primitive", "primitive_type": "%s" }},
+          "source": {
+            "type": "record_lookup",
+            "record_attribute": "foo-rating"
+          }
+        }"""
+            .formatted(mapKeyType, mapValueType)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
   public static WorkflowInputDefinition inputDefinitionWithArrayLiteral(
       Boolean nonEmpty, String arrayInnerType, String rawLiteralJson)
       throws JsonProcessingException {

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -112,7 +112,7 @@ public final class StockInputDefinitions {
         """
         {
           "input_name": "lookup_foo",
-          "input_type": { "type": "map", "key_type": { "type": "primitive", "primitive_type": "%s" }, "value_type": { "type": "primitive", "primitive_type": "%s" }},
+          "input_type": { "type": "map", "key_type": "%s", "value_type": { "type": "primitive", "primitive_type": "%s" }},
           "source": {
             "type": "record_lookup",
             "record_attribute": "foo-rating"

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
@@ -4,7 +4,7 @@ import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitio
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import bio.terra.cbas.common.exceptions.WorkflowAttributesNotFoundException;
+import bio.terra.cbas.common.exceptions.InputProcessingException;
 import bio.terra.cbas.model.ParameterDefinition;
 import bio.terra.cbas.model.ParameterDefinitionRecordLookup;
 import bio.terra.cbas.model.ParameterTypeDefinition;
@@ -53,7 +53,7 @@ class TestInputGeneratorBuildMapInputs {
 
   @Test
   void emptyMapLookup()
-      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+      throws JsonProcessingException, CoercionException, InputProcessingException {
     Map<String, Object> actual =
         InputGenerator.buildInputs(
             List.of(inputDefinitionWithMapFooRatingParameter("String", "String")),
@@ -65,7 +65,7 @@ class TestInputGeneratorBuildMapInputs {
 
   @Test
   void oneEntryMapLookup()
-      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+      throws JsonProcessingException, CoercionException, InputProcessingException {
 
     Map<String, Object> actual =
         InputGenerator.buildInputs(

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
@@ -1,0 +1,78 @@
+package bio.terra.cbas.runsets.inputs;
+
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithMapFooRatingParameter;
+import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.common.exceptions.WorkflowAttributesNotFoundException;
+import bio.terra.cbas.model.ParameterDefinition;
+import bio.terra.cbas.model.ParameterDefinitionRecordLookup;
+import bio.terra.cbas.model.ParameterTypeDefinition;
+import bio.terra.cbas.model.ParameterTypeDefinitionMap;
+import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
+import bio.terra.cbas.model.WorkflowInputDefinition;
+import bio.terra.cbas.runsets.types.CoercionException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TestInputGeneratorBuildMapInputs {
+
+  @Test
+  void workflowInputDefinitionParsingMaps() throws Exception {
+    WorkflowInputDefinition actualInputDefinition =
+        inputDefinitionWithMapFooRatingParameter("String", "Int");
+
+    ParameterTypeDefinition expectedInputTypeDefinition =
+        new ParameterTypeDefinitionMap()
+            .keyType(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.STRING)
+                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .valueType(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.INT)
+                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .type(ParameterTypeDefinition.TypeEnum.MAP);
+
+    ParameterDefinition expectedParameterDefinition =
+        new ParameterDefinitionRecordLookup()
+            .recordAttribute("foo-rating")
+            .type(ParameterDefinition.TypeEnum.RECORD_LOOKUP);
+
+    WorkflowInputDefinition expectedInputDefinition =
+        new WorkflowInputDefinition()
+            .inputName("lookup_foo")
+            .inputType(expectedInputTypeDefinition)
+            .source(expectedParameterDefinition);
+
+    assertEquals(expectedInputDefinition, actualInputDefinition);
+  }
+
+  @Test
+  void emptyMapLookup()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithMapFooRatingParameter("String", "String")),
+            wdsRecordWithFooRating("{}"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", Map.of());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void oneEntryMapLookup()
+      throws JsonProcessingException, CoercionException, WorkflowAttributesNotFoundException {
+
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(inputDefinitionWithMapFooRatingParameter("String", "Int")),
+            wdsRecordWithFooRating("{ \"five\": 5 }"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", Map.of("five", 5L));
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildMapInputs.java
@@ -27,10 +27,7 @@ class TestInputGeneratorBuildMapInputs {
 
     ParameterTypeDefinition expectedInputTypeDefinition =
         new ParameterTypeDefinitionMap()
-            .keyType(
-                new ParameterTypeDefinitionPrimitive()
-                    .primitiveType(PrimitiveParameterValueType.STRING)
-                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .keyType(PrimitiveParameterValueType.STRING)
             .valueType(
                 new ParameterTypeDefinitionPrimitive()
                     .primitiveType(PrimitiveParameterValueType.INT)

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
@@ -79,4 +79,25 @@ public final class StockOutputDefinitions {
 
     return objectMapper.readValue(rawOutputDefinition, new TypeReference<>() {});
   }
+
+  public static WorkflowOutputDefinition mapOutputDefinition(
+      String outputName,
+      String primitiveKeyType,
+      String primitiveValueType,
+      String recordAttributeName)
+      throws Exception {
+    String rawOutputDefinition =
+        """
+        {
+          "output_name":"%s",
+          "output_type": { "type": "map", "key_type": { "type": "primitive", "primitive_type": "%s" }, "value_type": { "type": "primitive", "primitive_type": "%s" }},
+          "destination": { "type": "record_update", "record_attribute": "%s" }
+        }
+        """
+            .formatted(outputName, primitiveKeyType, primitiveValueType, recordAttributeName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(rawOutputDefinition, new TypeReference<>() {});
+  }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/StockOutputDefinitions.java
@@ -90,7 +90,7 @@ public final class StockOutputDefinitions {
         """
         {
           "output_name":"%s",
-          "output_type": { "type": "map", "key_type": { "type": "primitive", "primitive_type": "%s" }, "value_type": { "type": "primitive", "primitive_type": "%s" }},
+          "output_type": { "type": "map", "key_type": "%s", "value_type": { "type": "primitive", "primitive_type": "%s" }},
           "destination": { "type": "record_update", "record_attribute": "%s" }
         }
         """

--- a/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorMaps.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/outputs/TestOutputGeneratorMaps.java
@@ -1,0 +1,37 @@
+package bio.terra.cbas.runsets.outputs;
+
+import static bio.terra.cbas.runsets.outputs.EngineOutputValueGenerator.singleCromwellOutput;
+import static bio.terra.cbas.runsets.outputs.StockOutputDefinitions.mapOutputDefinition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.model.WorkflowOutputDefinition;
+import com.google.gson.Gson;
+import cromwell.client.JSON;
+import java.util.List;
+import java.util.Map;
+import org.databiosphere.workspacedata.model.RecordAttributes;
+import org.junit.jupiter.api.Test;
+
+class TestOutputGeneratorMaps {
+  public TestOutputGeneratorMaps() {
+    JSON.setGson(new Gson());
+  }
+
+  private static List<WorkflowOutputDefinition> mapOutputDefinitions() throws Exception {
+    return List.of(mapOutputDefinition("myWorkflow.look_and_say", "String", "Int", "look_and_say"));
+  }
+
+  @Test
+  void stringArrayOutputs() throws Exception {
+
+    Object cromwellOutputs =
+        singleCromwellOutput("myWorkflow.look_and_say", "{ \"one\": 1, \"two\": 2 }");
+
+    RecordAttributes actual = OutputGenerator.buildOutputs(mapOutputDefinitions(), cromwellOutputs);
+
+    RecordAttributes expected = new RecordAttributes();
+    expected.put("look_and_say", Map.of("one", 1L, "two", 2L));
+
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
@@ -1,0 +1,50 @@
+package bio.terra.cbas.runsets.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.model.ParameterTypeDefinition;
+import bio.terra.cbas.model.ParameterTypeDefinitionMap;
+import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.PrimitiveParameterValueType;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class TestDefinitionParsing {
+
+  static ObjectMapper objectMapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Test
+  void parseMapDefinition() throws Exception {
+    String mapDefinition =
+        """
+        {
+         "type": "map",
+          "key_type": {
+            "type": "primitive",
+            "primitive_type": "String"
+          },
+          "value_type": {
+            "type": "primitive",
+            "primitive_type": "String"
+          }
+        }""";
+
+    ParameterTypeDefinition expectedType =
+        new ParameterTypeDefinitionMap()
+            .keyType(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.STRING)
+                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .valueType(
+                new ParameterTypeDefinitionPrimitive()
+                    .primitiveType(PrimitiveParameterValueType.STRING)
+                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .type(ParameterTypeDefinition.TypeEnum.MAP);
+    ParameterTypeDefinition actualType =
+        objectMapper.readValue(mapDefinition, new TypeReference<>() {});
+    assertEquals(expectedType, actualType);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
@@ -22,10 +22,7 @@ class TestDefinitionParsing {
         """
         {
          "type": "map",
-          "key_type": {
-            "type": "primitive",
-            "primitive_type": "String"
-          },
+          "key_type": "String",
           "value_type": {
             "type": "primitive",
             "primitive_type": "String"
@@ -34,10 +31,7 @@ class TestDefinitionParsing {
 
     ParameterTypeDefinition expectedType =
         new ParameterTypeDefinitionMap()
-            .keyType(
-                new ParameterTypeDefinitionPrimitive()
-                    .primitiveType(PrimitiveParameterValueType.STRING)
-                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+            .keyType(PrimitiveParameterValueType.STRING)
             .valueType(
                 new ParameterTypeDefinitionPrimitive()
                     .primitiveType(PrimitiveParameterValueType.STRING)


### PR DESCRIPTION
Allows for maps in CBAS input/output definitions like:

```json
{
 "type": "map",
  "key_type": "String",
  "value_type": {
    "type": "primitive",
    "primitive_type": "String"   }
}
```