### PR TITLE
[WM-1713] Don't return templated run sets in GET /run_sets API

### DIFF
--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -123,7 +123,7 @@ public class RunSetsApiController implements RunSetsApi {
           updatedRunSets.stream().map(this::convertToRunSetDetails).toList();
       response = new RunSetListResponse().runSets(filteredRunSetDetails);
     } else {
-      List<RunSet> runSets = runSetDao.getRunSets(Optional.ofNullable(pageSize).orElse(10));
+      List<RunSet> runSets = runSetDao.getRunSets(Optional.ofNullable(pageSize).orElse(10), false);
       updatedRunSets = smartRunSetsPoller.updateRunSets(runSets);
       List<RunSetDetailsResponse> runSetDetails =
           updatedRunSets.stream().map(this::convertToRunSetDetails).toList();

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -24,13 +24,15 @@ public class RunSetDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  public List<RunSet> getRunSets(Integer pageSize) {
+  public List<RunSet> getRunSets(Integer pageSize, boolean isTemplate) {
     String sql =
         "SELECT * FROM run_set "
-            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
+            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id AND run_set.is_template = :isTemplate "
             + "INNER JOIN method on method_version.method_id = method.method_id GROUP BY run_set.run_set_id, method_version.method_version_id, method.method_id ORDER BY MIN(run_set.submission_timestamp) DESC LIMIT :pageSize";
     return jdbcTemplate.query(
-        sql, new MapSqlParameterSource("pageSize", pageSize), new RunSetMapper());
+        sql,
+        new MapSqlParameterSource(Map.of("isTemplate", isTemplate, "pageSize", pageSize)),
+        new RunSetMapper());
   }
 
   public RunSet getRunSet(UUID runSetId) {

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -464,7 +464,7 @@ class TestRunSetsApiController {
             "BAR");
 
     List<RunSet> response = List.of(returnedRunSet1, returnedRunSet2);
-    when(runSetDao.getRunSets(any())).thenReturn(response);
+    when(runSetDao.getRunSets(any(), eq(false))).thenReturn(response);
     when(smartRunSetsPoller.updateRunSets(response)).thenReturn(response);
 
     MvcResult result =

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
@@ -79,5 +79,8 @@ class TestRunSetDao {
     // DB has no non-templated run sets, so it will return empty list
     List<RunSet> runSets = runSetDao.getRunSets(10, false);
     assertEquals(0, runSets.size());
+
+    List<RunSet> templateRunSets = runSetDao.getRunSets(10, true);
+    assertEquals(3, templateRunSets.size());
   }
 }

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
@@ -76,8 +76,8 @@ class TestRunSetDao {
 
   @Test
   void retrievesAllRunSets() {
-
-    List<RunSet> runSets = runSetDao.getRunSets(10);
-    assertEquals(3, runSets.size());
+    // DB has no non-templated run sets, so it will return empty list
+    List<RunSet> runSets = runSetDao.getRunSets(10, false);
+    assertEquals(0, runSets.size());
   }
 }


### PR DESCRIPTION
Tested locally:
GET /run_sets doesn't return templated run sets and  UI only displays 1 submission that I had run as expected
![Screen Shot 2023-02-14 at 3 24 06 PM](https://user-images.githubusercontent.com/16748522/218853753-ae12b426-1f79-4d43-97da-54305e381c2a.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1713