### PR TITLE
[WM-1722] Ensure order for Covid-19 methods

### DIFF
--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -62,3 +62,6 @@ databaseChangeLog:
   - include:
       file: changesets/20230207_sarscov2_nextstrain_nonempty_optionals.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20230217_ensure_covid_19_methods_order.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20230217_ensure_covid_19_methods_order.yaml
+++ b/service/src/main/resources/changelog/changesets/20230217_ensure_covid_19_methods_order.yaml
@@ -9,18 +9,18 @@ databaseChangeLog:
             columns:
               - column:
                   name: created
-                  valueDate: "NOW() - interval '10 minutes'"
+                  valueDate: "NOW() - interval '45 minutes'"
         - update:
             tableName: method
             where: method_id='00000000-0000-0000-0000-000000000005' # assemble_refbased
             columns:
               - column:
                   name: created
-                  valueDate: "NOW() - interval '5 minutes'"
+                  valueDate: "NOW() - interval '30 minutes'"
         - update:
             tableName: method
             where: method_id='00000000-0000-0000-0000-000000000008' # fetch_sra_to_bam
             columns:
               - column:
                   name: created
-                  valueDate: "NOW()"
+                  valueDate: "NOW() - interval '15 minutes'"

--- a/service/src/main/resources/changelog/changesets/20230217_ensure_covid_19_methods_order.yaml
+++ b/service/src/main/resources/changelog/changesets/20230217_ensure_covid_19_methods_order.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: "update created column for Covid-19 workflows to ensure their order"
+      author: sshah
+      changes:
+        - update:
+            tableName: method
+            where: method_id='00000000-0000-0000-0000-000000000006' # sarscov2_nextstrain
+            columns:
+              - column:
+                  name: created
+                  valueDate: "NOW() - interval '10 minutes'"
+        - update:
+            tableName: method
+            where: method_id='00000000-0000-0000-0000-000000000005' # assemble_refbased
+            columns:
+              - column:
+                  name: created
+                  valueDate: "NOW() - interval '5 minutes'"
+        - update:
+            tableName: method
+            where: method_id='00000000-0000-0000-0000-000000000008' # fetch_sra_to_bam
+            columns:
+              - column:
+                  name: created
+                  valueDate: "NOW()"

--- a/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
@@ -75,5 +75,12 @@ class TestMethodDao {
 
     assertTrue(allMethods.stream().anyMatch(m -> m.methodId().equals(method1.methodId())));
     assertTrue(allMethods.stream().anyMatch(m -> m.methodId().equals(method2.methodId())));
+
+    // ensure that methods are listed in desc order of creation
+    assertEquals(method2.methodId(), allMethods.get(0).methodId());
+    assertEquals(method1.methodId(), allMethods.get(1).methodId());
+    assertEquals("fetch_sra_to_bam", allMethods.get(2).name());
+    assertEquals("assemble_refbased", allMethods.get(3).name());
+    assertEquals("sarscov2_nextstrain", allMethods.get(4).name());
   }
 }

--- a/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
@@ -71,7 +71,7 @@ class TestMethodDao {
   void retrievesAllMethods() {
     List<Method> allMethods = methodDao.getMethods();
 
-    assertEquals(5, allMethods.size()); // because database has 5 pre-staged workflows
+    assertEquals(5, allMethods.size()); // because database has 3 pre-staged workflows
 
     assertTrue(allMethods.stream().anyMatch(m -> m.methodId().equals(method1.methodId())));
     assertTrue(allMethods.stream().anyMatch(m -> m.methodId().equals(method2.methodId())));


### PR DESCRIPTION
The methods appear in the order as expected:
![Screen Shot 2023-02-17 at 2 26 18 PM](https://user-images.githubusercontent.com/16748522/219768162-673f4404-4174-4a4d-9b76-a0e6ec07d364.png)


Closes https://broadworkbench.atlassian.net/browse/WM-1722