### PR TITLE
WM-1635, WM-1642: Struct type support in CBAS backend

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -389,17 +389,19 @@ components:
           type: string
           description: Indicates what type of parameter declaration this is.
           required: true
-          enum: [ literal, record_lookup, none ]
+          enum: [ literal, record_lookup, object_builder, none ]
           example: record_lookup
       oneOf:
         - $ref: '#/components/schemas/ParameterDefinitionRecordLookup'
         - $ref: '#/components/schemas/ParameterDefinitionLiteralValue'
+        - $ref: '#/components/schemas/ParameterDefinitionObjectBuilder'
         - $ref: '#/components/schemas/ParameterDefinitionNone'
       discriminator:
         propertyName: "type"
         mapping:
           literal: 'ParameterDefinitionLiteralValue'
           record_lookup: 'ParameterDefinitionRecordLookup'
+          object_builder: 'ParameterDefinitionObjectBuilder'
           none: 'ParameterDefinitionNone'
 
     ParameterDefinitionLiteralValue:
@@ -421,11 +423,26 @@ components:
           description: The attribute name on the record to use.
           required: true
           example: record_field_foo_rating
+    ParameterDefinitionObjectBuilder:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ParameterDefinition'
+      properties:
+        fields:
+          type: object
+          items:
+            $ref: '#/components/schemas/ObjectBuilderField'
+    ObjectBuilderField:
+      type: object
+      properties:
+        "name":
+          type: string
+        source:
+          $ref: '#/components/schemas/ParameterDefinition'
     ParameterDefinitionNone:
       type: object
       allOf:
         - $ref: '#/components/schemas/ParameterDefinition'
-
 
     OutputDestination:
       title: OutputDestination

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -279,13 +279,14 @@ components:
           type: string
           description: Indicates what type of parameter type definition this is.
           required: true
-          enum: [ primitive, optional, array, map ]
+          enum: [ primitive, optional, array, map, struct ]
           example: record_lookup
       oneOf:
         - $ref: '#/components/schemas/ParameterTypeDefinitionPrimitive'
         - $ref: '#/components/schemas/ParameterTypeDefinitionOptional'
         - $ref: '#/components/schemas/ParameterTypeDefinitionArray'
         - $ref: '#/components/schemas/ParameterTypeDefinitionMap'
+        - $ref: '#/components/schemas/ParameterTypeDefinitionStruct'
       discriminator:
         propertyName: "type"
         mapping:
@@ -293,6 +294,7 @@ components:
           optional: 'ParameterTypeDefinitionOptional'
           array: 'ParameterTypeDefinitionArray'
           map: 'ParameterTypeDefinitionMap'
+          struct: 'ParameterTypeDefinitionStruct'
 
     PrimitiveParameterValueType:
       title: PrimitiveParameterValueType
@@ -344,6 +346,33 @@ components:
         key_type:
           $ref: PrimitiveParameterValueType
         value_type:
+          $ref: ParameterTypeDefinition
+
+    ParameterTypeDefinitionStruct:
+      type: object
+      required:
+        - name
+        - fields
+      allOf:
+        - $ref: '#/components/schemas/ParameterTypeDefinition'
+      properties:
+        name:
+          type: string
+          description: The name of the struct
+        fields:
+          type: array
+          items:
+            $ref: StructField
+
+    StructField:
+      type: object
+      required:
+        - field_name
+        - field_type
+      properties:
+        field_name:
+          type: string
+        field_type:
           $ref: ParameterTypeDefinition
 
     # This ParameterDefinition holds the 'oneOf' declaration for all the various types that can

--- a/service/src/main/java/bio/terra/cbas/common/exceptions/InputProcessingException.java
+++ b/service/src/main/java/bio/terra/cbas/common/exceptions/InputProcessingException.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.common.exceptions;
 
 import bio.terra.cbas.model.ParameterDefinition;
+import bio.terra.cbas.model.ParameterTypeDefinition;
 
 public class InputProcessingException extends Exception {
 
@@ -20,7 +21,24 @@ public class InputProcessingException extends Exception {
 
   public static class WorkflowInputSourceNotSupportedException extends InputProcessingException {
     public WorkflowInputSourceNotSupportedException(ParameterDefinition parameterSource) {
-      super("Unsupported input source type: " + parameterSource.getClass().getSimpleName());
+      super("Unsupported input source type: " + parameterSource.getType().toString());
+    }
+  }
+
+  public static class StructMissingFieldException extends InputProcessingException {
+    public StructMissingFieldException(String missingFieldName, String structName) {
+      super(
+          "Could not build a %s struct. Required field %s was not provided."
+              .formatted(structName, missingFieldName));
+    }
+  }
+
+  public static class InappropriateInputSourceException extends InputProcessingException {
+    public InappropriateInputSourceException(
+        ParameterDefinition sourceType, ParameterTypeDefinition valueType) {
+      super(
+          "Cannot use a source of type %s to specify an input value of type %s."
+              .formatted(sourceType.getType(), valueType.getType()));
     }
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/inputs/InputGenerator.java
@@ -65,7 +65,8 @@ public class InputGenerator {
     } else if (parameterSource instanceof ParameterDefinitionNone) {
       parameterValue = null;
     } else if (parameterSource instanceof ParameterDefinitionRecordLookup recordLookup) {
-      parameterValue = handleRecordLookupInput(parameterName, inputType, recordResponse, recordLookup);
+      parameterValue =
+          handleRecordLookupInput(parameterName, inputType, recordResponse, recordLookup);
     } else if (parameterSource instanceof ParameterDefinitionObjectBuilder objectBuilderSource) {
       parameterValue = handleObjectBuilderInput(inputType, recordResponse, objectBuilderSource);
     } else {
@@ -82,7 +83,12 @@ public class InputGenerator {
   }
 
   @Nullable
-  private static Object handleRecordLookupInput(String parameterName, ParameterTypeDefinition inputType, RecordResponse recordResponse, ParameterDefinitionRecordLookup recordLookup) throws WorkflowAttributesNotFoundException {
+  private static Object handleRecordLookupInput(
+      String parameterName,
+      ParameterTypeDefinition inputType,
+      RecordResponse recordResponse,
+      ParameterDefinitionRecordLookup recordLookup)
+      throws WorkflowAttributesNotFoundException {
     Object parameterValue;
     String attributeName = recordLookup.getRecordAttribute();
 
@@ -100,7 +106,11 @@ public class InputGenerator {
   }
 
   @NotNull
-  private static Object handleObjectBuilderInput(ParameterTypeDefinition inputType, RecordResponse recordResponse, ParameterDefinitionObjectBuilder objectBuilderSource) throws InputProcessingException, CoercionException {
+  private static Object handleObjectBuilderInput(
+      ParameterTypeDefinition inputType,
+      RecordResponse recordResponse,
+      ParameterDefinitionObjectBuilder objectBuilderSource)
+      throws InputProcessingException, CoercionException {
     Object parameterValue;
     Map<String, Object> fields = new HashMap<>();
     if (inputType instanceof ParameterTypeDefinitionStruct structInputType) {

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasStruct.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasStruct.java
@@ -1,0 +1,61 @@
+package bio.terra.cbas.runsets.types;
+
+import bio.terra.cbas.model.ParameterTypeDefinitionStruct;
+import bio.terra.cbas.model.StructField;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CbasStruct implements CbasValue {
+
+  private final String structName;
+  private final Map<String, CbasValue> fields;
+
+  public CbasStruct(String structName, Map<String, CbasValue> fields) {
+    this.fields = fields;
+    this.structName = structName;
+  }
+
+  public String getStructName() {
+    return structName;
+  }
+
+  public Map<String, CbasValue> getFields() {
+    return fields;
+  }
+
+  @Override
+  public Object asSerializableValue() {
+    return fields.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().asSerializableValue()));
+  }
+
+  @Override
+  public long countFiles() {
+    return fields.values().stream().mapToLong(CbasValue::countFiles).sum();
+  }
+
+  public static CbasStruct parseValue(ParameterTypeDefinitionStruct structDefinition, Object values)
+      throws CoercionException {
+    if (values instanceof Map<?, ?> valueMap) {
+      HashMap<String, CbasValue> coercedValues = new HashMap<>();
+
+      for (StructField field : structDefinition.getFields()) {
+        if (valueMap.containsKey(field.getFieldName())) {
+          coercedValues.put(
+              field.getFieldName(),
+              CbasValue.parseValue(field.getFieldType(), valueMap.get(field.getFieldName())));
+        } else {
+          throw new ValueCoercionException(
+              values,
+              "Struct (%s)".formatted(structDefinition.getName()),
+              "Field %s not provided in input for Struct (%s)"
+                  .formatted(field.getFieldName(), structDefinition.getName()));
+        }
+      }
+      return new CbasStruct(structDefinition.getName(), coercedValues);
+    } else {
+      throw new TypeCoercionException(values, "Struct (%s)".formatted(structDefinition.getName()));
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/types/CbasValue.java
@@ -5,6 +5,7 @@ import bio.terra.cbas.model.ParameterTypeDefinitionArray;
 import bio.terra.cbas.model.ParameterTypeDefinitionMap;
 import bio.terra.cbas.model.ParameterTypeDefinitionOptional;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.ParameterTypeDefinitionStruct;
 import bio.terra.cbas.model.PrimitiveParameterValueType;
 
 public interface CbasValue {
@@ -47,6 +48,8 @@ public interface CbasValue {
       PrimitiveParameterValueType keyType = mapDefinition.getKeyType();
       ParameterTypeDefinition valueType = mapDefinition.getValueType();
       return CbasMap.parseValue(keyType, valueType, value);
+    } else if (parameterType instanceof ParameterTypeDefinitionStruct structDefinition) {
+      return CbasStruct.parseValue(structDefinition, value);
     } else {
       throw new TypeCoercionException(value, parameterType.toString());
     }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -155,11 +155,8 @@ public final class StockInputDefinitions {
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
 
-  public static WorkflowInputDefinition
-      inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder(
-          String fieldName, String fieldType) throws JsonProcessingException {
-    String paramDefinitionJson =
-        """
+  private static String oneFieldStructInputDefinitionTemplate =
+      """
         {
           "input_name": "lookup_foo",
           "input_type": {
@@ -183,8 +180,25 @@ public final class StockInputDefinitions {
               }
             }]
           }
-        }"""
+        }""";
+
+  public static WorkflowInputDefinition
+      inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder(
+          String fieldName, String fieldType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        oneFieldStructInputDefinitionTemplate
             .formatted(fieldName, fieldType, fieldName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
+  public static WorkflowInputDefinition nestedStructInputDefinitionWithBadFieldNamesInSource(
+      String fieldName, String fieldType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        oneFieldStructInputDefinitionTemplate
+            .formatted(fieldName, fieldType, fieldName + "oops")
             .stripIndent()
             .trim();
 
@@ -235,6 +249,30 @@ public final class StockInputDefinitions {
           }
         }"""
             .formatted(fieldName, innerFieldName, innerFieldType, fieldName, innerFieldName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
+  public static WorkflowInputDefinition objectBuilderSourceUsedForStringInput()
+      throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": { "type": "primitive", "primitive_type": "string" },
+          "source": {
+            "type": "object_builder",
+            "fields": [{
+              "name": "struct_field",
+              "source": {
+                "type": "record_lookup",
+                "record_attribute": "foo-rating"
+              }
+            }]
+          }
+        }"""
             .stripIndent()
             .trim();
 

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -155,6 +155,42 @@ public final class StockInputDefinitions {
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
 
+  public static WorkflowInputDefinition
+      inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder(
+          String fieldName, String fieldType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": {
+            "type": "struct",
+            "name": "StructName",
+            "fields": [{
+              "field_name": "%s",
+              "field_type": {
+                "type": "primitive",
+                "primitive_type": "%s"
+              }
+            }]
+          },
+          "source": {
+            "type": "object_builder",
+            "fields": [{
+              "name": "%s",
+              "source": {
+                "type": "record_lookup",
+                "record_attribute": "foo-rating"
+              }
+            }]
+          }
+        }"""
+            .formatted(fieldName, fieldType, fieldName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
   public static WorkflowInputDefinition inputDefinitionWithArrayLiteral(
       Boolean nonEmpty, String arrayInnerType, String rawLiteralJson)
       throws JsonProcessingException {

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -125,6 +125,36 @@ public final class StockInputDefinitions {
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
 
+  public static WorkflowInputDefinition
+      inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup(
+          String fieldName, String fieldType) throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": {
+            "type": "struct",
+            "name": "StructName",
+            "fields": [{
+              "field_name": "%s",
+              "field_type": {
+                "type": "primitive",
+                "primitive_type": "%s"
+              }
+            }]
+          },
+          "source": {
+            "type": "record_lookup",
+            "record_attribute": "foo-rating"
+          }
+        }"""
+            .formatted(fieldName, fieldType)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
   public static WorkflowInputDefinition inputDefinitionWithArrayLiteral(
       Boolean nonEmpty, String arrayInnerType, String rawLiteralJson)
       throws JsonProcessingException {

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/StockInputDefinitions.java
@@ -191,6 +191,56 @@ public final class StockInputDefinitions {
     return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
   }
 
+  public static WorkflowInputDefinition
+      inputDefinitionWithOneNestedFieldStructFooRatingParameterObjectBuilder(
+          String fieldName, String innerFieldName, String innerFieldType)
+          throws JsonProcessingException {
+    String paramDefinitionJson =
+        """
+        {
+          "input_name": "lookup_foo",
+          "input_type": {
+            "type": "struct",
+            "name": "StructName1",
+            "fields": [{
+              "field_name": "%s",
+              "field_type": {
+                "type": "struct",
+                "name": "StructName2",
+                "fields": [{
+                  "field_name": "%s",
+                  "field_type": {
+                    "type": "primitive",
+                    "primitive_type": "%s"
+                  }
+                }]
+              }
+            }]
+          },
+          "source": {
+            "type": "object_builder",
+            "fields": [{
+              "name": "%s",
+              "source": {
+                "type": "object_builder",
+                "fields": [{
+                  "name": "%s",
+                  "source": {
+                    "type": "record_lookup",
+                    "record_attribute": "foo-rating"
+                  }
+                }]
+              }
+            }]
+          }
+        }"""
+            .formatted(fieldName, innerFieldName, innerFieldType, fieldName, innerFieldName)
+            .stripIndent()
+            .trim();
+
+    return objectMapper.readValue(paramDefinitionJson, WorkflowInputDefinition.class);
+  }
+
   public static WorkflowInputDefinition inputDefinitionWithArrayLiteral(
       Boolean nonEmpty, String arrayInnerType, String rawLiteralJson)
       throws JsonProcessingException {

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
@@ -76,11 +76,11 @@ class TestInputGeneratorBuildStructInputs {
     assertThrows(
         ValueCoercionException.class,
         () ->
-        InputGenerator.buildInputs(
-            List.of(
-                inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup(
-                    "struct_field", "Int")),
-            wdsRecordWithFooRating("{ \"struct_field_BAD\": 5 }")));
+            InputGenerator.buildInputs(
+                List.of(
+                    inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup(
+                        "struct_field", "Int")),
+                wdsRecordWithFooRating("{ \"struct_field_BAD\": 5 }")));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
@@ -1,5 +1,6 @@
 package bio.terra.cbas.runsets.inputs;
 
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder;
 import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,7 +48,7 @@ class TestInputGeneratorBuildStructInputs {
   }
 
   @Test
-  void oneFieldStructLookup()
+  void oneFieldStructRecordLookup()
       throws JsonProcessingException, CoercionException, InputProcessingException {
 
     Map<String, Object> actual =
@@ -56,6 +57,21 @@ class TestInputGeneratorBuildStructInputs {
                 inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup(
                     "struct_field", "Int")),
             wdsRecordWithFooRating("{ \"struct_field\": 5 }"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", Map.of("struct_field", 5L));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void oneFieldStructObjectBuilder()
+      throws JsonProcessingException, CoercionException, InputProcessingException {
+
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(
+                inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder(
+                    "struct_field", "Int")),
+            wdsRecordWithFooRating("5"));
 
     Map<String, Object> expected = Map.of("lookup_foo", Map.of("struct_field", 5L));
     assertEquals(expected, actual);

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
@@ -2,6 +2,7 @@ package bio.terra.cbas.runsets.inputs;
 
 import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneFieldStructFooRatingParameterObjectBuilder;
 import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup;
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneNestedFieldStructFooRatingParameterObjectBuilder;
 import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -74,6 +75,22 @@ class TestInputGeneratorBuildStructInputs {
             wdsRecordWithFooRating("5"));
 
     Map<String, Object> expected = Map.of("lookup_foo", Map.of("struct_field", 5L));
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void nestedOneFieldStructObjectBuilder()
+      throws JsonProcessingException, CoercionException, InputProcessingException {
+
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(
+                inputDefinitionWithOneNestedFieldStructFooRatingParameterObjectBuilder(
+                    "struct_field", "inner_struct_field", "Int")),
+            wdsRecordWithFooRating("5"));
+
+    Map<String, Object> expected =
+        Map.of("lookup_foo", Map.of("struct_field", Map.of("inner_struct_field", 5L)));
     assertEquals(expected, actual);
   }
 }

--- a/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/inputs/TestInputGeneratorBuildStructInputs.java
@@ -1,0 +1,63 @@
+package bio.terra.cbas.runsets.inputs;
+
+import static bio.terra.cbas.runsets.inputs.StockInputDefinitions.inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup;
+import static bio.terra.cbas.runsets.inputs.StockWdsRecordResponses.wdsRecordWithFooRating;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.common.exceptions.InputProcessingException;
+import bio.terra.cbas.model.*;
+import bio.terra.cbas.runsets.types.CoercionException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TestInputGeneratorBuildStructInputs {
+
+  @Test
+  void workflowInputDefinitionParsingStructs() throws Exception {
+    WorkflowInputDefinition actualInputDefinition =
+        inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup("struct_field", "Int");
+
+    ParameterTypeDefinition expectedInputTypeDefinition =
+        new ParameterTypeDefinitionStruct()
+            .name("StructName")
+            .fields(
+                List.of(
+                    new StructField()
+                        .fieldName("struct_field")
+                        .fieldType(
+                            new ParameterTypeDefinitionPrimitive()
+                                .primitiveType(PrimitiveParameterValueType.INT)
+                                .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))))
+            .type(ParameterTypeDefinition.TypeEnum.STRUCT);
+
+    ParameterDefinition expectedParameterDefinition =
+        new ParameterDefinitionRecordLookup()
+            .recordAttribute("foo-rating")
+            .type(ParameterDefinition.TypeEnum.RECORD_LOOKUP);
+
+    WorkflowInputDefinition expectedInputDefinition =
+        new WorkflowInputDefinition()
+            .inputName("lookup_foo")
+            .inputType(expectedInputTypeDefinition)
+            .source(expectedParameterDefinition);
+
+    assertEquals(expectedInputDefinition, actualInputDefinition);
+  }
+
+  @Test
+  void oneFieldStructLookup()
+      throws JsonProcessingException, CoercionException, InputProcessingException {
+
+    Map<String, Object> actual =
+        InputGenerator.buildInputs(
+            List.of(
+                inputDefinitionWithOneFieldStructFooRatingParameterRecordLookup(
+                    "struct_field", "Int")),
+            wdsRecordWithFooRating("{ \"struct_field\": 5 }"));
+
+    Map<String, Object> expected = Map.of("lookup_foo", Map.of("struct_field", 5L));
+    assertEquals(expected, actual);
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/types/TestDefinitionParsing.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.cbas.model.ParameterTypeDefinition;
 import bio.terra.cbas.model.ParameterTypeDefinitionMap;
 import bio.terra.cbas.model.ParameterTypeDefinitionPrimitive;
+import bio.terra.cbas.model.ParameterTypeDefinitionStruct;
 import bio.terra.cbas.model.PrimitiveParameterValueType;
+import bio.terra.cbas.model.StructField;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TestDefinitionParsing {
@@ -39,6 +42,84 @@ class TestDefinitionParsing {
             .type(ParameterTypeDefinition.TypeEnum.MAP);
     ParameterTypeDefinition actualType =
         objectMapper.readValue(mapDefinition, new TypeReference<>() {});
+    assertEquals(expectedType, actualType);
+  }
+
+  @Test
+  void parseStructDefinition() throws Exception {
+    String structDefinition =
+        """
+        {
+          "type": "struct",
+          "name": "Pet",
+          "fields": [{
+            "field_name": "name",
+            "field_type": {
+              "type": "primitive",
+              "primitive_type": "String"
+            }
+          }, {
+            "field_name": "species",
+            "field_type": {
+              "type": "struct",
+              "name": "PetSpecies",
+              "fields": [{
+                "field_name": "species_name",
+                "field_type": {
+                  "type": "primitive",
+                  "primitive_type": "String"
+                }
+              }, {
+                "field_name": "breed_name",
+                "field_type": {
+                  "type": "primitive",
+                  "primitive_type": "String"
+                }
+              }]
+            }
+          }]
+        }""";
+
+    ParameterTypeDefinition expectedType =
+        new ParameterTypeDefinitionStruct()
+            .name("Pet")
+            .fields(
+                List.of(
+                    new StructField()
+                        .fieldName("name")
+                        .fieldType(
+                            new ParameterTypeDefinitionPrimitive()
+                                .primitiveType(PrimitiveParameterValueType.STRING)
+                                .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE)),
+                    new StructField()
+                        .fieldName("species")
+                        .fieldType(
+                            new ParameterTypeDefinitionStruct()
+                                .name("PetSpecies")
+                                .fields(
+                                    List.of(
+                                        new StructField()
+                                            .fieldName("species_name")
+                                            .fieldType(
+                                                new ParameterTypeDefinitionPrimitive()
+                                                    .primitiveType(
+                                                        PrimitiveParameterValueType.STRING)
+                                                    .type(
+                                                        ParameterTypeDefinition.TypeEnum
+                                                            .PRIMITIVE)),
+                                        new StructField()
+                                            .fieldName("breed_name")
+                                            .fieldType(
+                                                new ParameterTypeDefinitionPrimitive()
+                                                    .primitiveType(
+                                                        PrimitiveParameterValueType.STRING)
+                                                    .type(
+                                                        ParameterTypeDefinition.TypeEnum
+                                                            .PRIMITIVE))))
+                                .type(ParameterTypeDefinition.TypeEnum.STRUCT))))
+            .type(ParameterTypeDefinition.TypeEnum.STRUCT);
+    ParameterTypeDefinition actualType =
+        objectMapper.readValue(structDefinition, new TypeReference<>() {});
     assertEquals(expectedType, actualType);
   }
 }


### PR DESCRIPTION
As an implementation note, it turned out that the "Direct Field Access from WDS" option to specify where structs come from (see [conversation](https://docs.google.com/document/d/1WFQjd1RUuK3hgTkZ_JF1W8X1Q54k4kvW4YrI-yaScnI/edit#bookmark=id.mkcfx24ge0o6)) was so easy to implement, we basically got it for free. I've added a test case for it.