### PR TITLE
[WM-1809] Update terra-common-lib to 0.0.78 that filters out tokens when logging requests

### DIFF
--- a/buildSrc/src/main/groovy/java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-common-conventions.gradle
@@ -49,7 +49,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.0.53-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.0.78-SNAPSHOT'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
terra-common-lib (TCL) version `0.0.78-SNAPSHOT` filters out `cookie` header from requests when logging.

TCL PR: https://github.com/DataBiosphere/terra-common-lib/pull/97

Closes https://broadworkbench.atlassian.net/browse/WM-1809