### PR TITLE
[WM-1840] Inputs with truthy `optional` field in WomTool should also be considered optional

### DIFF
--- a/service/src/main/java/bio/terra/cbas/util/methods/WomtoolToCbasInputsAndOutputs.java
+++ b/service/src/main/java/bio/terra/cbas/util/methods/WomtoolToCbasInputsAndOutputs.java
@@ -102,9 +102,7 @@ public final class WomtoolToCbasInputsAndOutputs {
   }
 
   public static ParameterDefinition getSource(
-      String inputName,
-      String defaultValue,
-      Map<String, ParameterDefinition> methodInputMappingMap) {
+      String inputName, Map<String, ParameterDefinition> methodInputMappingMap) {
     if (methodInputMappingMap.containsKey(inputName)) {
       return methodInputMappingMap.get(inputName);
     } else {
@@ -134,8 +132,7 @@ public final class WomtoolToCbasInputsAndOutputs {
       workflowInputDefinition.inputType(getInputType(input.getOptional(), input.getValueType()));
 
       // Source
-      workflowInputDefinition.source(
-          getSource(workflowInputName, input.getDefault(), methodInputMappingAsMap));
+      workflowInputDefinition.source(getSource(workflowInputName, methodInputMappingAsMap));
 
       cbasInputDefinition.add(workflowInputDefinition);
     }

--- a/service/src/main/java/bio/terra/cbas/util/methods/WomtoolToCbasInputsAndOutputs.java
+++ b/service/src/main/java/bio/terra/cbas/util/methods/WomtoolToCbasInputsAndOutputs.java
@@ -6,7 +6,7 @@ import bio.terra.cbas.model.MethodOutputMapping;
 import bio.terra.cbas.model.OutputDestination;
 import bio.terra.cbas.model.OutputDestinationNone;
 import bio.terra.cbas.model.ParameterDefinition;
-import bio.terra.cbas.model.ParameterDefinitionLiteralValue;
+import bio.terra.cbas.model.ParameterDefinitionNone;
 import bio.terra.cbas.model.ParameterTypeDefinition;
 import bio.terra.cbas.model.ParameterTypeDefinitionArray;
 import bio.terra.cbas.model.ParameterTypeDefinitionMap;
@@ -57,9 +57,7 @@ public final class WomtoolToCbasInputsAndOutputs {
           .primitiveType(PrimitiveParameterValueType.FLOAT)
           .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE);
       case OPTIONAL -> new ParameterTypeDefinitionOptional()
-          .optionalType(
-              getParameterType(Objects.requireNonNull(valueType.getOptionalType()))
-                  .type(ParameterTypeDefinition.TypeEnum.OPTIONAL))
+          .optionalType(getParameterType(Objects.requireNonNull(valueType.getOptionalType())))
           .type(ParameterTypeDefinition.TypeEnum.OPTIONAL);
       case ARRAY -> new ParameterTypeDefinitionArray()
           .nonEmpty(valueType.getNonEmpty())
@@ -92,6 +90,17 @@ public final class WomtoolToCbasInputsAndOutputs {
     };
   }
 
+  public static ParameterTypeDefinition getInputType(boolean isOptional, ValueType inputValueType)
+      throws WomtoolValueTypeNotFoundException {
+    if (isOptional && inputValueType.getTypeName() != ValueType.TypeNameEnum.OPTIONAL) {
+      return new ParameterTypeDefinitionOptional()
+          .optionalType(getParameterType(Objects.requireNonNull(inputValueType)))
+          .type(ParameterTypeDefinition.TypeEnum.OPTIONAL);
+    } else {
+      return getParameterType(inputValueType);
+    }
+  }
+
   public static ParameterDefinition getSource(
       String inputName,
       String defaultValue,
@@ -99,9 +108,7 @@ public final class WomtoolToCbasInputsAndOutputs {
     if (methodInputMappingMap.containsKey(inputName)) {
       return methodInputMappingMap.get(inputName);
     } else {
-      return new ParameterDefinitionLiteralValue()
-          .parameterValue(defaultValue)
-          .type(ParameterDefinition.TypeEnum.NONE);
+      return new ParameterDefinitionNone().type(ParameterDefinition.TypeEnum.NONE);
     }
   }
 
@@ -124,7 +131,7 @@ public final class WomtoolToCbasInputsAndOutputs {
       workflowInputDefinition.inputName(workflowInputName);
 
       // Input type
-      workflowInputDefinition.inputType(getParameterType(input.getValueType()));
+      workflowInputDefinition.inputType(getInputType(input.getOptional(), input.getValueType()));
 
       // Source
       workflowInputDefinition.source(

--- a/service/src/test/java/bio/terra/cbas/util/methods/TestWomtoolToCbasInputsAndOutputs.java
+++ b/service/src/test/java/bio/terra/cbas/util/methods/TestWomtoolToCbasInputsAndOutputs.java
@@ -15,6 +15,7 @@ import bio.terra.cbas.model.OutputDestination;
 import bio.terra.cbas.model.OutputDestinationNone;
 import bio.terra.cbas.model.OutputDestinationRecordUpdate;
 import bio.terra.cbas.model.ParameterDefinition;
+import bio.terra.cbas.model.ParameterDefinitionNone;
 import bio.terra.cbas.model.ParameterDefinitionLiteralValue;
 import bio.terra.cbas.model.ParameterDefinitionRecordLookup;
 import bio.terra.cbas.model.ParameterTypeDefinition;
@@ -90,37 +91,49 @@ class TestWomtoolToCbasInputsAndOutputs {
    * Testing the womToCbasInputBuilder() function
    * */
   @Test
-  void test_multiple_string_inputs() throws WomtoolValueTypeNotFoundException {
+  void test_multiple_inputs() throws WomtoolValueTypeNotFoundException {
     String womtoolStringInputs =
         """
-        {
-          "valid": true,
-          "errors": [],
-          "validWorkflow": true,
-          "name": "test",
-          "inputs": [
             {
-              "name": "hello",
-              "valueType": {
-                "typeName": "String"
-              },
-              "typeDisplayName": "String",
-              "optional": true,
-              "default": "Workflow Management"
-            },
-            {
-              "name": "foo",
-              "valueType": {
-                "typeName": "String"
-              },
-              "typeDisplayName": "String",
-              "optional": true,
-              "default": null
-            }
-          ],
-          "outputs": []
-         }
-        """;
+              "valid": true,
+              "errors": [],
+              "validWorkflow": true,
+              "name": "test",
+              "inputs": [
+                {
+                  "name": "hello",
+                  "valueType": {
+                    "typeName": "String"
+                  },
+                  "typeDisplayName": "String",
+                  "optional": false,
+                  "default": "Workflow Management"
+                },
+                {
+                  "name": "foo",
+                  "valueType": {
+                    "typeName": "String"
+                  },
+                  "typeDisplayName": "String",
+                  "optional": true,
+                  "default": null
+                },
+                {
+                  "name": "bar",
+                  "valueType": {
+                    "typeName": "Optional",
+                    "optionalType": {
+                      "typeName": "Int"
+                    }
+                  },
+                  "typeDisplayName": "Int?",
+                  "optional": true,
+                  "default": null
+                }
+              ],
+              "outputs": []
+             }
+            """;
 
     Gson object = new Gson();
     WorkflowDescription womtoolDescription =
@@ -133,24 +146,33 @@ class TestWomtoolToCbasInputsAndOutputs {
                 new ParameterTypeDefinitionPrimitive()
                     .primitiveType(PrimitiveParameterValueType.STRING)
                     .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
-            .source(
-                new ParameterDefinitionLiteralValue()
-                    .parameterValue("Workflow Management")
-                    .type(ParameterDefinition.TypeEnum.NONE));
+            .source(new ParameterDefinitionNone().type(ParameterDefinition.TypeEnum.NONE));
     WorkflowInputDefinition input2 =
         new WorkflowInputDefinition()
             .inputName("test.foo")
             .inputType(
-                new ParameterTypeDefinitionPrimitive()
-                    .primitiveType(PrimitiveParameterValueType.STRING)
-                    .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
-            .source(
-                new ParameterDefinitionLiteralValue()
-                    .parameterValue(null)
-                    .type(ParameterDefinition.TypeEnum.NONE));
+                new ParameterTypeDefinitionOptional()
+                    .optionalType(
+                        new ParameterTypeDefinitionPrimitive()
+                            .primitiveType(PrimitiveParameterValueType.STRING)
+                            .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+                    .type(ParameterTypeDefinition.TypeEnum.OPTIONAL))
+            .source(new ParameterDefinitionNone().type(ParameterDefinition.TypeEnum.NONE));
+    WorkflowInputDefinition input3 =
+        new WorkflowInputDefinition()
+            .inputName("test.bar")
+            .inputType(
+                new ParameterTypeDefinitionOptional()
+                    .optionalType(
+                        new ParameterTypeDefinitionPrimitive()
+                            .primitiveType(PrimitiveParameterValueType.INT)
+                            .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
+                    .type(ParameterTypeDefinition.TypeEnum.OPTIONAL))
+            .source(new ParameterDefinitionNone().type(ParameterDefinition.TypeEnum.NONE));
 
     cbasInputDef.add(input1);
     cbasInputDef.add(input2);
+    cbasInputDef.add(input3);
 
     assertEquals(cbasInputDef, womToCbasInputBuilder(womtoolDescription, new ArrayList<>()));
   }
@@ -575,7 +597,7 @@ class TestWomtoolToCbasInputsAndOutputs {
         .optionalType(
             new ParameterTypeDefinitionPrimitive()
                 .primitiveType(PrimitiveParameterValueType.STRING)
-                .type(ParameterTypeDefinition.TypeEnum.OPTIONAL))
+                .type(ParameterTypeDefinition.TypeEnum.PRIMITIVE))
         .type(ParameterTypeDefinition.TypeEnum.OPTIONAL);
 
     assertEquals(cbasParameterTypeDef, getParameterType(womtoolString));
@@ -794,4 +816,9 @@ class TestWomtoolToCbasInputsAndOutputs {
         defaultDestinationDefinition,
         getDestination("hello_world.output_name_1", methodOutputMappingAsMap));
   }
+
+  //  @Test
+  //  void getInputTypeForInputWithOptionalTrue() {
+  //
+  //  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'cbas'
 include('service', 'integration', 'client')
 
-gradle.ext.releaseVersion = '0.0.107'
+gradle.ext.releaseVersion = '0.0.108'


### PR DESCRIPTION
This PR introduces that change that when converting WomTool input definition to CBAS input definition, inputs with truthy `optional` field will also be considered Optional inputs. Additionally, the source of all inputs will be set to `ParameterDefinitionNone` as there is no need to provide default values (for now).

For example, consider this input that had the below definiton in WomTool
```
{
  "name": "CellMetrics.cpu",
  "valueType": {
    "typeName": "Int"
  },
  "typeDisplayName": "Int",
  "optional": true,
  "default": "4"
}
```
was previously being converted to this (for CBAS input definition)
```
{
  "input_name": "Optimus.CellMetrics.cpu",
  "input_type": {
    "type": "primitive",
    "primitive_type": "Int"
  },
  "source": {
    "type": "none",
    "parameter_value": "4"
  }
}
```
will now be converted to this since it has `optional: true`
```
{
  "input_name": "Optimus.CellMetrics.cpu",
  "input_type": {
    "type": "optional",
    "optional_type": {
      "type": "primitive",
      "primitive_type": "Int"
    }
  },
  "source": {
    "type": "none"
  }
}
```

Closes https://broadworkbench.atlassian.net/browse/WM-1840