### PR TITLE
[WM-1572] Attach JIRA ID to commit in publish.yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
       tagOverride:
         description: 'Specify the tag to use for this publish'
         required: true
+      jiraIdOverride:
+        description: 'JIRA ticket number'
+        required: true
 
 env:
   SERVICE_NAME: cbas
@@ -25,6 +28,19 @@ jobs:
       id-token: 'write'
 
     steps:
+      - name: Ensure that a Jira ID is present in the commit message
+        id: ensure-jira-id
+        run: |
+          JIRA_ID=${{ github.event.inputs.jiraIdOverride }}
+          if [[ ! -z "${JIRA_ID}" ]]
+          then
+            echo ::set-output name=JIRA_ID::${JIRA_ID}
+          else
+            JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
+            [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
+            echo ::set-output name=JIRA_ID::${JIRA_ID}
+          fi
+
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -112,5 +128,5 @@ jobs:
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
-          git commit -am "Auto update CBAS version to $HELM_NEW_TAG"
+          git commit -am "${{ steps.ensure-jira-id.outputs.JIRA_ID }}: Auto update CBAS version to $HELM_NEW_TAG"
           git push https://broadbot:$BROADBOT_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,9 +125,10 @@ jobs:
           HELM_NEW_TAG=${{ steps.tag.outputs.TAG }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           # prefixing search and replacement text with 'cbas' is needed to avoid replacing tag for cbas-ui
+          # when both cbas and cbas-ui have the same image version
           sed -i "s/cbas:$HELM_CUR_TAG/cbas:$HELM_NEW_TAG/" terra-batch-libchart/values.yaml
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
-          git commit -am "${{ steps.ensure-jira-id.outputs.JIRA_ID }}: Auto update CBAS version to $HELM_NEW_TAG"
+          git commit -am "[${{ steps.ensure-jira-id.outputs.JIRA_ID }}] Auto update CBAS version to $HELM_NEW_TAG"
           git push https://broadbot:$BROADBOT_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,8 @@ jobs:
           HELM_CUR_TAG=$(grep "/cbas:" terra-batch-libchart/values.yaml | sed "s,.*/cbas:,,")
           HELM_NEW_TAG=${{ steps.tag.outputs.TAG }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
-          sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" terra-batch-libchart/values.yaml
+          # prefixing search and replacement text with 'cbas' is needed to avoid replacing tag for cbas-ui
+          sed -i "s/cbas:$HELM_CUR_TAG/cbas:$HELM_NEW_TAG/" terra-batch-libchart/values.yaml
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"


### PR DESCRIPTION
Manually ran publish action to test it:
Successful publish workflow run: https://github.com/DataBiosphere/cbas/actions/runs/4866009438/jobs/8677035710
Commit in cromwhelm repo that updates CBAS image now has JIRA ID prefixed to the commit and it only updates cbas tag: https://github.com/broadinstitute/cromwhelm/commit/e785fc683e7aa7b500e18c72539aaa1454c551e3
![Screenshot 2023-05-02 at 5 43 39 PM](https://user-images.githubusercontent.com/16748522/235792666-045477cd-0023-4e3e-8d1b-b010af073c17.png)
Successful creation of auto-merge Leo PR with JIRA ID: https://github.com/DataBiosphere/leonardo/pull/3320

Closes https://broadworkbench.atlassian.net/browse/WM-1572