### PR TITLE
[WM-2122] Add Sam client

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/SamServerConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/SamServerConfiguration.java
@@ -1,0 +1,6 @@
+package bio.terra.cbas.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sam")
+public record SamServerConfiguration(String baseUri, Boolean debugApiLogging) {}

--- a/service/src/main/java/bio/terra/cbas/dependencies/common/ScheduledHealthChecker.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/common/ScheduledHealthChecker.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.dependencies.common;
 
 import bio.terra.cbas.dependencies.leonardo.LeonardoService;
+import bio.terra.cbas.dependencies.sam.SamService;
 import bio.terra.cbas.dependencies.wds.WdsService;
 import bio.terra.cbas.dependencies.wes.CromwellService;
 import java.util.Map;
@@ -26,13 +27,17 @@ public class ScheduledHealthChecker {
 
   @Autowired
   public ScheduledHealthChecker(
-      CromwellService cromwellService, WdsService wdsService, LeonardoService leonardoService) {
+      CromwellService cromwellService,
+      WdsService wdsService,
+      LeonardoService leonardoService,
+      SamService samService) {
     this.healthCheckStatuses = new ConcurrentHashMap<>();
     this.healthCheckSystems =
         Map.of(
             "cromwell", cromwellService,
             "wds", wdsService,
-            "leonardo", leonardoService);
+            "leonardo", leonardoService,
+            "sam", samService);
   }
 
   @Scheduled(

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
@@ -1,0 +1,26 @@
+package bio.terra.cbas.dependencies.sam;
+
+import bio.terra.cbas.config.SamServerConfiguration;
+import okhttp3.OkHttpClient;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SamClient {
+
+  private final SamServerConfiguration samServerConfiguration;
+  private final OkHttpClient singletonHttpClient;
+
+  public SamClient(SamServerConfiguration samServerConfiguration) {
+    this.samServerConfiguration = samServerConfiguration;
+    this.singletonHttpClient = new ApiClient().getHttpClient();
+  }
+
+  public ApiClient getApiClient() {
+    return new ApiClient()
+        .setHttpClient(singletonHttpClient)
+        .addDefaultHeader("Connection", "close")
+        .setBasePath(samServerConfiguration.baseUri())
+        .setDebugging(samServerConfiguration.debugApiLogging());
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
@@ -1,0 +1,31 @@
+package bio.terra.cbas.dependencies.sam;
+
+import bio.terra.cbas.dependencies.common.HealthCheck;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SamService implements HealthCheck {
+
+  private final SamClient samClient;
+
+  public SamService(SamClient samClient) {
+    this.samClient = samClient;
+  }
+
+  private StatusApi getStatusApi() {
+    return new StatusApi(samClient.getApiClient());
+  }
+
+  @Override
+  public Result checkHealth() {
+    try {
+      SystemStatus result = getStatusApi().getSystemStatus();
+      return new Result(result.getOk(), result.toString());
+    } catch (ApiException e) {
+      return new Result(false, e.getMessage());
+    }
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -87,3 +87,7 @@ terra.common:
   tracing:
     stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}
+
+sam:
+  baseUri: "https://sam.dsde-dev.broadinstitute.org/"
+  debugApiLogging: false


### PR DESCRIPTION
Related Cromwhelm PR: https://github.com/broadinstitute/cromwhelm/pull/266

Testing:
I was able to test CBAS and chart changes by deploying them to a running Workflows app in dev. Logs from CBAS pod after upgrade shows Sam url being passed and successful health check:
```
...
{"timestampSeconds":1690567109,"timestampNanos":344000000,"severity":"INFO","message":"Started App in 61.901 seconds (JVM running for 67.713)","serviceContext":{"service":"cbas","version":"unknown"},"context":"default","thread":"main","logger":"bio.terra.cbas.App","logging.googleapis.com/sourceLocation":{"file":"org/springframework/boot/StartupInfoLogger.java","line":61,"function":"org.springframework.boot.StartupInfoLogger.logStarted"}}
##### Sam url: https://sam.dsde-dev.broadinstitute.org:443
{"timestampSeconds":1690567112,"timestampNanos":239000000,"severity":"INFO","message":"Azure Identity => Attempted credential EnvironmentCredential is unavailable.","serviceContext":{"service":"cbas","version":"unknown"},"context":"default","thread":"ForkJoinPool.commonPool-worker-1","logger":"com.azure.identity.ChainedTokenCredential","logging.googleapis.com/sourceLocation":{"file":"com/azure/core/util/logging/ClientLogger.java","line":493,"function":"com.azure.core.util.logging.ClientLogger.performLogging"}}
{"timestampSeconds":1690567112,"timestampNanos":239000000,"severity":"ERROR","message":"WorkloadIdentityCredential authentication unavailable. The workload options are not fully configured. See the troubleshooting guide for more information. https://aka.ms/azsdk/java/identity/workloadidentitycredential/troubleshoot","serviceContext":{"service":"cbas","version":"unknown"},"context":"default","thread":"ForkJoinPool.commonPool-worker-1","logger":"com.azure.identity.WorkloadIdentityCredential","logging.googleapis.com/sourceLocation":{"file":"com/azure/core/util/logging/ClientLogger.java","line":505,"function":"com.azure.core.util.logging.ClientLogger.performLogging"}}
{"timestampSeconds":1690567112,"timestampNanos":240000000,"severity":"INFO","message":"Azure Identity => Attempted credential WorkloadIdentityCredential is unavailable.","serviceContext":{"service":"cbas","version":"unknown"},"context":"default","thread":"ForkJoinPool.commonPool-worker-1","logger":"com.azure.identity.ChainedTokenCredential","logging.googleapis.com/sourceLocation":{"file":"com/azure/core/util/logging/ClientLogger.java","line":493,"function":"com.azure.core.util.logging.ClientLogger.performLogging"}}
{"timestampSeconds":1690567114,"timestampNanos":342000000,"severity":"INFO","message":"Health check for sam is true. Message: class SystemStatus {\n    ok: true\n    systems: {GoogleGroups={ok=true}, GooglePubSub={ok=true}, GoogleIam={ok=true}, Database={ok=true}}\n}","serviceContext":{"service":"cbas","version":"unknown"},"context":"default","thread":"scheduling-1","logger":"bio.terra.cbas.dependencies.common.ScheduledHealthChecker","logging.googleapis.com/sourceLocation":{"file":"bio/terra/cbas/dependencies/common/ScheduledHealthChecker.java","line":53,"function":"bio.terra.cbas.dependencies.common.ScheduledHealthChecker.lambda$checkHealth$0"}}
```

Closes https://broadworkbench.atlassian.net/browse/WM-2122