### PR TITLE
[WM-2093] Add user id to RunSet

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -751,8 +751,6 @@ components:
           type: string
         call_caching_enabled:
           type: boolean
-        user_id:
-          type: string
         state:
           $ref: '#/components/schemas/RunSetState'
         record_type:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -751,6 +751,8 @@ components:
           type: string
         call_caching_enabled:
           type: boolean
+        user_id:
+          type: string
         state:
           $ref: '#/components/schemas/RunSetState'
         record_type:

--- a/service/src/main/java/bio/terra/cbas/controllers/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/GlobalExceptionHandler.java
@@ -4,8 +4,8 @@ import bio.terra.cbas.config.BeanConfig;
 import bio.terra.cbas.model.ErrorReport;
 import bio.terra.common.exception.AbstractGlobalExceptionHandler;
 import bio.terra.common.exception.ErrorReportException;
-import java.util.List;
 import bio.terra.common.iam.BearerToken;
+import java.util.List;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +22,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler extends AbstractGlobalExceptionHandler<ErrorReport> {
   /**
-   * This method allows for error uncovering of custom exceptions that we throw inside bean creation,
-   * especially the {@link BearerToken} bean in {@link BeanConfig}. If the root cause does not stem
-   * from our own custom errors, it will be reported by our catch all handler as an internal server
-   * error.
+   * This method allows for error uncovering of custom exceptions that we throw inside bean
+   * creation, especially the {@link BearerToken} bean in {@link BeanConfig}. If the root cause does
+   * not stem from our own custom errors, it will be reported by our catch all handler as an
+   * internal server error.
    */
   @ExceptionHandler(BeanCreationException.class)
   public ResponseEntity<ErrorReport> beanCreationErrorHandler(BeanCreationException ex) {

--- a/service/src/main/java/bio/terra/cbas/controllers/MethodsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/MethodsApiController.java
@@ -268,6 +268,7 @@ public class MethodsApiController implements MethodsApi {
             0,
             objectMapper.writeValueAsString(inputs),
             objectMapper.writeValueAsString(outputs),
+            null,
             null);
 
     methodDao.createMethod(method);

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -166,9 +166,6 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<RunSetStateResponse> postRunSet(RunSetRequest request) {
-    UserStatusInfo user = samService.getSamUser();
-    log.info("User ID: {}", user.getUserSubjectId()); // TODO: remove in WM-2093
-
     captureRequestMetrics(request);
 
     // request validation
@@ -228,6 +225,8 @@ public class RunSetsApiController implements RunSetsApi {
           new RunSetStateResponse().errors(errorMsg), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    UserStatusInfo user = samService.getSamUser();
+
     // Create a new run_set
     UUID runSetId = this.uuidSource.generateUUID();
     RunSet runSet;
@@ -249,7 +248,8 @@ public class RunSetsApiController implements RunSetsApi {
               0,
               objectMapper.writeValueAsString(request.getWorkflowInputDefinitions()),
               objectMapper.writeValueAsString(request.getWorkflowOutputDefinitions()),
-              request.getWdsRecords().getRecordType());
+              request.getWdsRecords().getRecordType(),
+              user.getUserSubjectId());
     } catch (JsonProcessingException e) {
       log.warn("Failed to record run set to database", e);
       return new ResponseEntity<>(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -66,8 +66,8 @@ public class RunSetDao {
 
   public int createRunSet(RunSet runSet) {
     return jdbcTemplate.update(
-        "insert into run_set (run_set_id, method_version_id, run_set_name, run_set_description, call_caching_enabled, is_template, status, submission_timestamp, last_modified_timestamp, last_polled_timestamp, run_count, error_count, input_definition, output_definition, record_type)"
-            + " values (:runSetId, :methodVersionId, :name, :description, :callCachingEnabled, :isTemplate, :status, :submissionTimestamp, :lastModifiedTimestamp, :lastPolledTimestamp, :runCount, :errorCount, :inputDefinition, :outputDefinition, :recordType)",
+        "insert into run_set (run_set_id, method_version_id, run_set_name, run_set_description, call_caching_enabled, is_template, status, submission_timestamp, last_modified_timestamp, last_polled_timestamp, run_count, error_count, input_definition, output_definition, record_type, user_id)"
+            + " values (:runSetId, :methodVersionId, :name, :description, :callCachingEnabled, :isTemplate, :status, :submissionTimestamp, :lastModifiedTimestamp, :lastPolledTimestamp, :runCount, :errorCount, :inputDefinition, :outputDefinition, :recordType, :userId)",
         new EnumAwareBeanPropertySqlParameterSource(runSet));
   }
 

--- a/service/src/main/java/bio/terra/cbas/dao/mappers/RunSetMapper.java
+++ b/service/src/main/java/bio/terra/cbas/dao/mappers/RunSetMapper.java
@@ -32,6 +32,7 @@ public class RunSetMapper implements RowMapper<RunSet> {
         rs.getInt(RunSet.ERROR_COUNT_COL),
         rs.getString(RunSet.INPUT_DEFINITION_COL),
         rs.getString(RunSet.OUTPUT_DEFINITION_COL),
-        rs.getString(RunSet.RECORD_TYPE_COL));
+        rs.getString(RunSet.RECORD_TYPE_COL),
+        rs.getString(RunSet.USER_ID_COL));
   }
 }

--- a/service/src/main/java/bio/terra/cbas/models/RunSet.java
+++ b/service/src/main/java/bio/terra/cbas/models/RunSet.java
@@ -18,7 +18,8 @@ public record RunSet(
     Integer errorCount,
     String inputDefinition,
     String outputDefinition,
-    String recordType) {
+    String recordType,
+    String userId) {
 
   // Corresponding table column names in database
   public static final String RUN_SET_ID_COL = "run_set_id";
@@ -35,6 +36,7 @@ public record RunSet(
   public static final String INPUT_DEFINITION_COL = "input_definition";
   public static final String OUTPUT_DEFINITION_COL = "output_definition";
   public static final String RECORD_TYPE_COL = "record_type";
+  public static final String USER_ID_COL = "user_id";
 
   public UUID getMethodVersionId() {
     return methodVersion.methodVersionId();

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -80,3 +80,6 @@ databaseChangeLog:
   - include:
       file: changesets/20230711_add_call_caching_enabled_column.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20230808_add_user_id_column.yaml
+      relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20230808_add_user_id_column.yaml
+++ b/service/src/main/resources/changelog/changesets/20230808_add_user_id_column.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add user_id column to run_set table"
+      author: scottdil
+      changes:
+        - addColumn:
+            tableName: run_set
+            columns:
+              - column:
+                  name: user_id
+                  type: text

--- a/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiController.java
@@ -697,7 +697,8 @@ class TestMethodsApiController {
           0,
           "[]",
           "[]",
-          "FOO");
+          "FOO",
+          "user-foo");
 
   private static final MethodLastRunDetails method2Version1RunsetDetails =
       new MethodLastRunDetails()
@@ -723,7 +724,8 @@ class TestMethodsApiController {
           0,
           "[]",
           "[]",
-          "FOO");
+          "FOO",
+          "user-foo");
 
   private static final MethodLastRunDetails method2Version2RunsetDetails =
       new MethodLastRunDetails()

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -379,6 +379,7 @@ class TestRunSetsApiController {
     assertEquals(recordType, newRunSetCaptor.getValue().recordType());
     assertEquals(outputDefinitionAsString, newRunSetCaptor.getValue().outputDefinition());
     assertEquals(isCallCachingEnabled, newRunSetCaptor.getValue().callCachingEnabled());
+    assertEquals(mockUser.getUserSubjectId(), newRunSetCaptor.getValue().userId());
 
     ArgumentCaptor<Run> newRunCaptor = ArgumentCaptor.forClass(Run.class);
     verify(runDao, times(3)).createRun(newRunCaptor.capture());
@@ -719,7 +720,8 @@ class TestRunSetsApiController {
             1,
             "inputdefinition",
             "outputDefinition",
-            "FOO");
+            "FOO",
+            mockUser.getUserSubjectId());
 
     RunSet returnedRunSet2 =
         new RunSet(
@@ -750,7 +752,8 @@ class TestRunSetsApiController {
             0,
             "inputdefinition",
             "outputDefinition",
-            "BAR");
+            "BAR",
+            mockUser.getUserSubjectId());
 
     List<RunSet> response = List.of(returnedRunSet1, returnedRunSet2);
     when(runSetDao.getRunSets(any(), eq(false))).thenReturn(response);
@@ -819,7 +822,8 @@ class TestRunSetsApiController {
             0,
             "inputdefinition",
             "outputDefinition",
-            "FOO");
+            "FOO",
+            mockUser.getUserSubjectId());
 
     Run run1 =
         new Run(
@@ -897,7 +901,8 @@ class TestRunSetsApiController {
             0,
             "inputdefinition",
             "outputDefinition",
-            "FOO");
+            "FOO",
+            mockUser.getUserSubjectId());
 
     Run run1 =
         new Run(

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -92,7 +92,8 @@ class TestRunsApiController {
           0,
           "inputDefinition",
           "outputDefinition",
-          "entitytype");
+          "entitytype",
+          "user-foo");
 
   private static final Run returnedRun =
       new Run(

--- a/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
@@ -211,7 +211,8 @@ class VerifyPactsAllControllers {
             1,
             "my input definition string",
             "my output definition string",
-            "myRecordType");
+            "myRecordType",
+            "user-foo");
 
     List<RunSet> response = List.of(targetRunSet);
 
@@ -240,6 +241,7 @@ class VerifyPactsAllControllers {
             null,
             null,
             1,
+            null,
             null,
             null,
             null,

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
@@ -60,7 +60,8 @@ class TestRunSetDao {
             0,
             null,
             null,
-            "sample");
+            "sample",
+            "user-foo");
 
     RunSet actual = runSetDao.getRunSet(UUID.fromString("10000000-0000-0000-0000-000000000008"));
 

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestRunSetAbortManager.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestRunSetAbortManager.java
@@ -61,6 +61,7 @@ class TestRunSetAbortManager {
             0,
             null,
             null,
+            null,
             null);
 
     Run run1Running =
@@ -147,6 +148,7 @@ class TestRunSetAbortManager {
             null,
             2,
             0,
+            null,
             null,
             null,
             null);

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunSetsPoller.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunSetsPoller.java
@@ -64,6 +64,7 @@ public class TestSmartRunSetsPoller {
             0,
             null,
             null,
+            null,
             null);
 
     UUID runSetId2 = UUID.randomUUID();
@@ -81,6 +82,7 @@ public class TestSmartRunSetsPoller {
             OffsetDateTime.now().minusMinutes(3),
             1,
             0,
+            null,
             null,
             null,
             null);
@@ -141,6 +143,7 @@ public class TestSmartRunSetsPoller {
             0,
             null,
             null,
+            null,
             null);
 
     RunSet runSetUpdated =
@@ -157,6 +160,7 @@ public class TestSmartRunSetsPoller {
             null,
             2,
             0,
+            null,
             null,
             null,
             null);
@@ -248,6 +252,7 @@ public class TestSmartRunSetsPoller {
             0,
             null,
             null,
+            null,
             null);
 
     RunSet runSetTimestampUpdated =
@@ -264,6 +269,7 @@ public class TestSmartRunSetsPoller {
             OffsetDateTime.now(),
             1,
             0,
+            null,
             null,
             null,
             null);

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
@@ -127,7 +127,8 @@ public class TestSmartRunsPollerFunctional {
           0,
           "inputDefinition",
           outputDefinition,
-          "entityType");
+          "entityType",
+          "user-foo");
 
   final Run runToUpdate1 =
       new Run(
@@ -680,7 +681,8 @@ public class TestSmartRunsPollerFunctional {
             0,
             "inputDefinition",
             outputDefinition,
-            "entityType");
+            "entityType",
+            "user-foo");
 
     Run run =
         new Run(


### PR DESCRIPTION
This PR adds a `user_id` column to the `run_set` table, which is populated based on the token provided in the request. There are many files that were updated just to include the extra parameter in the RunSet constructor, so I have commented where the important changes were made.

Note that this PR does not expose `user_id` on API responses - it's simply responsible for storing this new field in the database.