### PR TITLE
[WM-2125] CBAS checks user auth with Sam for all APIs

### DIFF
--- a/service/src/main/java/bio/terra/cbas/common/exceptions/ForbiddenException.java
+++ b/service/src/main/java/bio/terra/cbas/common/exceptions/ForbiddenException.java
@@ -1,0 +1,16 @@
+package bio.terra.cbas.common.exceptions;
+
+import bio.terra.common.exception.ErrorReportException;
+import java.util.ArrayList;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends ErrorReportException {
+
+  public ForbiddenException(String samResourceType, String samActionType) {
+    super(
+        "User doesn't have '%s' permission on '%s' resource"
+            .formatted(samActionType, samResourceType),
+        new ArrayList<>(),
+        HttpStatus.FORBIDDEN);
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/config/SamServerConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/SamServerConfiguration.java
@@ -3,4 +3,5 @@ package bio.terra.cbas.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "sam")
-public record SamServerConfiguration(String baseUri, Boolean debugApiLogging) {}
+public record SamServerConfiguration(
+    String baseUri, Boolean debugApiLogging, String workspaceId, Boolean checkAuthAccess) {}

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -14,6 +14,7 @@ import static bio.terra.cbas.models.CbasRunStatus.UNKNOWN;
 import bio.terra.cbas.api.RunSetsApi;
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.common.MethodUtil;
+import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.common.exceptions.InputProcessingException;
 import bio.terra.cbas.common.exceptions.MethodProcessingException.UnknownMethodSourceException;
 import bio.terra.cbas.config.CbasApiConfiguration;
@@ -63,10 +64,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedata.client.ApiException;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.RecordResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -87,6 +89,7 @@ public class RunSetsApiController implements RunSetsApi {
   private final SmartRunSetsPoller smartRunSetsPoller;
   private final UuidSource uuidSource;
   private final RunSetAbortManager abortManager;
+  private static final Logger logger = LoggerFactory.getLogger(RunSetsApiController.class);
 
   private record WdsRecordResponseDetails(
       ArrayList<RecordResponse> recordResponseList, Map<String, String> recordIdsWithError) {}
@@ -141,6 +144,14 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<RunSetListResponse> getRunSets(UUID methodId, Integer pageSize) {
+    // check if current user has read permissions on the workspace
+    if (!samService.hasReadPermission()) {
+      logger.info(
+          "User doesn't have '%s' permission on '%s' resource"
+              .formatted(samService.READ_ACTION, samService.RESOURCE_TYPE_WORKSPACE));
+      throw new ForbiddenException(samService.RESOURCE_TYPE_WORKSPACE, samService.READ_ACTION);
+    }
+
     RunSetListResponse response;
 
     List<RunSet> filteredRunSet;
@@ -166,6 +177,14 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<RunSetStateResponse> postRunSet(RunSetRequest request) {
+    // check if current user has compute permissions on the workspace
+    if (!samService.hasComputePermission()) {
+      logger.info(
+          "User doesn't have '%s' permission on '%s' resource"
+              .formatted(samService.COMPUTE_ACTION, samService.RESOURCE_TYPE_WORKSPACE));
+      throw new ForbiddenException(samService.RESOURCE_TYPE_WORKSPACE, samService.COMPUTE_ACTION);
+    }
+
     captureRequestMetrics(request);
 
     // request validation
@@ -296,6 +315,14 @@ public class RunSetsApiController implements RunSetsApi {
 
   @Override
   public ResponseEntity<AbortRunSetResponse> abortRunSet(UUID runSetId) {
+    // check if current user has compute permissions on the workspace
+    if (!samService.hasComputePermission()) {
+      logger.info(
+          "User doesn't have '%s' permission on '%s' resource"
+              .formatted(samService.COMPUTE_ACTION, samService.RESOURCE_TYPE_WORKSPACE));
+      throw new ForbiddenException(samService.RESOURCE_TYPE_WORKSPACE, samService.COMPUTE_ACTION);
+    }
+
     AbortRunSetResponse aborted = new AbortRunSetResponse();
 
     aborted.runSetId(runSetId);

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedata.client.ApiException;
 import org.databiosphere.workspacedata.model.ErrorResponse;
 import org.databiosphere.workspacedata.model.RecordResponse;

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -2,7 +2,9 @@ package bio.terra.cbas.controllers;
 
 import bio.terra.cbas.api.RunsApi;
 import bio.terra.cbas.common.DateUtils;
+import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.dao.RunDao;
+import bio.terra.cbas.dependencies.sam.SamService;
 import bio.terra.cbas.model.RunLog;
 import bio.terra.cbas.model.RunLogResponse;
 import bio.terra.cbas.models.CbasRunStatus;
@@ -11,6 +13,8 @@ import bio.terra.cbas.monitoring.TimeLimitedUpdater.UpdateResult;
 import bio.terra.cbas.runsets.monitoring.SmartRunsPoller;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -18,11 +22,14 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class RunsApiController implements RunsApi {
   private final SmartRunsPoller smartPoller;
+  private final SamService samService;
   private final RunDao runDao;
+  private static final Logger logger = LoggerFactory.getLogger(RunsApiController.class);
 
-  public RunsApiController(RunDao runDao, SmartRunsPoller smartPoller) {
+  public RunsApiController(RunDao runDao, SmartRunsPoller smartPoller, SamService samService) {
     this.runDao = runDao;
     this.smartPoller = smartPoller;
+    this.samService = samService;
   }
 
   private RunLog runToRunLog(Run run) {
@@ -45,6 +52,13 @@ public class RunsApiController implements RunsApi {
 
   @Override
   public ResponseEntity<RunLogResponse> getRuns(UUID runSetId) {
+    // check if current user has read permissions on the workspace
+    if (!samService.hasReadPermission()) {
+      logger.info(
+          "User doesn't have '%s' permission on '%s' resource"
+              .formatted(samService.READ_ACTION, samService.RESOURCE_TYPE_WORKSPACE));
+      throw new ForbiddenException(samService.RESOURCE_TYPE_WORKSPACE, samService.READ_ACTION);
+    }
 
     List<Run> queryResults = runDao.getRuns(new RunDao.RunsFilters(runSetId, null));
     UpdateResult<Run> updatedRunsResult = smartPoller.updateRuns(queryResults);

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
@@ -29,4 +29,12 @@ public class SamClient {
     apiClient.setAccessToken(accessToken);
     return apiClient;
   }
+
+  public String getWorkspaceId() {
+    return this.samServerConfiguration.workspaceId();
+  }
+
+  public boolean checkAuthAccessWithSam() {
+    return this.samServerConfiguration.checkAuthAccess();
+  }
 }

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
@@ -6,10 +6,13 @@ import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.common.sam.exception.SamExceptionFactory;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,6 +20,20 @@ public class SamService implements HealthCheck {
 
   private final SamClient samClient;
   private final BearerToken bearerToken;
+
+  // Sam resource type name for Workspaces
+  public final String RESOURCE_TYPE_WORKSPACE = "workspace";
+
+  // Sam action name for read permission
+  public final String READ_ACTION = "read";
+
+  // Sam action name for write permission
+  public final String WRITE_ACTION = "write";
+
+  // Sam action name for compute  permission
+  public final String COMPUTE_ACTION = "compute";
+
+  private static final Logger logger = LoggerFactory.getLogger(SamService.class);
 
   public SamService(SamClient samClient, BearerToken bearerToken) {
     this.samClient = samClient;
@@ -27,8 +44,38 @@ public class SamService implements HealthCheck {
     return new StatusApi(samClient.getApiClient());
   }
 
+  boolean hasPermission(String actionType) {
+    // don't check auth access with Sam if "sam.checkAuthAccess" is false
+    if (!samClient.checkAuthAccessWithSam()) return true;
+
+    logger.debug(
+        "Checking Sam permission for '%s' resource and '%s' action type for user on workspace '%s'."
+            .formatted(RESOURCE_TYPE_WORKSPACE, actionType, samClient.getWorkspaceId()));
+
+    try {
+      ResourcesApi resourcesApi = getResourcesApi();
+      return SamRetry.retry(
+          () ->
+              resourcesApi.resourcePermissionV2(
+                  RESOURCE_TYPE_WORKSPACE, samClient.getWorkspaceId(), actionType));
+    } catch (ApiException e) {
+      throw SamExceptionFactory.create(
+          "Error checking %s permissions on workspace from Sam".formatted(actionType), e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw SamExceptionFactory.create(
+          "Request interrupted while checking %s permissions on workspace from Sam"
+              .formatted(actionType),
+          e);
+    }
+  }
+
   public UsersApi getUsersApi() {
     return new UsersApi(samClient.getApiClient(bearerToken.getToken()));
+  }
+
+  public ResourcesApi getResourcesApi() {
+    return new ResourcesApi(samClient.getApiClient(bearerToken.getToken()));
   }
 
   // Borrowed from WDS
@@ -53,5 +100,17 @@ public class SamService implements HealthCheck {
     } catch (ApiException e) {
       return new Result(false, e.getMessage());
     }
+  }
+
+  public boolean hasReadPermission() {
+    return hasPermission(READ_ACTION);
+  }
+
+  public boolean hasWritePermission() {
+    return hasPermission(WRITE_ACTION);
+  }
+
+  public boolean hasComputePermission() {
+    return hasPermission(COMPUTE_ACTION);
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -91,3 +91,7 @@ terra.common:
 sam:
   baseUri: "https://sam.dsde-dev.broadinstitute.org/"
   debugApiLogging: false
+  # this should be same as "wds.instanceId"
+  workspaceId: "15f36863-30a5-4cab-91f7-52be439f1175"
+  # for local testing this can be set to false
+  checkAuthAccess: true

--- a/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiControllerUnits.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiControllerUnits.java
@@ -8,6 +8,7 @@ import bio.terra.cbas.dao.MethodDao;
 import bio.terra.cbas.dao.MethodVersionDao;
 import bio.terra.cbas.dao.RunSetDao;
 import bio.terra.cbas.dependencies.dockstore.DockstoreService;
+import bio.terra.cbas.dependencies.sam.SamService;
 import bio.terra.cbas.dependencies.wes.CromwellService;
 import bio.terra.cbas.model.MethodInputMapping;
 import bio.terra.cbas.model.MethodOutputMapping;
@@ -38,6 +39,7 @@ class TestMethodsApiControllerUnits {
   @Autowired private MockMvc mockMvc;
   @MockBean private CromwellService cromwellService;
   @MockBean private DockstoreService dockstoreService;
+  @MockBean private SamService samService;
 
   // These mock beans are supplied to the RunSetApiController at construction time (and get used
   // later):
@@ -159,6 +161,7 @@ class TestMethodsApiControllerUnits {
         new MethodsApiController(
             cromwellService,
             dockstoreService,
+            samService,
             methodDao,
             methodVersionDao,
             runSetDao,

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -319,6 +319,10 @@ class TestRunSetsApiController {
         .thenReturn(new RunId().runId(cromwellWorkflowId3));
 
     doReturn(mockUser).when(samService).getSamUser();
+
+    // setup Sam permission check to return true
+    when(samService.hasReadPermission()).thenReturn(true);
+    when(samService.hasComputePermission()).thenReturn(true);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.config.CbasApiConfiguration;
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.dao.MethodDao;
@@ -39,6 +40,7 @@ import bio.terra.cbas.dependencies.wds.WdsServiceApiException;
 import bio.terra.cbas.dependencies.wes.CromwellClient;
 import bio.terra.cbas.dependencies.wes.CromwellService;
 import bio.terra.cbas.model.AbortRunSetResponse;
+import bio.terra.cbas.model.ErrorReport;
 import bio.terra.cbas.model.OutputDestination;
 import bio.terra.cbas.model.RunSetDetailsResponse;
 import bio.terra.cbas.model.RunSetListResponse;
@@ -57,7 +59,9 @@ import bio.terra.cbas.runsets.monitoring.RunSetAbortManager;
 import bio.terra.cbas.runsets.monitoring.RunSetAbortManager.AbortRequestDetails;
 import bio.terra.cbas.runsets.monitoring.SmartRunSetsPoller;
 import bio.terra.cbas.util.UuidSource;
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.BearerToken;
+import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import bio.terra.dockstore.model.ToolDescriptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -76,10 +80,10 @@ import org.databiosphere.workspacedata.model.RecordResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -204,7 +208,7 @@ class TestRunSetsApiController {
   @MockBean private BearerToken bearerToken;
   @MockBean private SamClient samClient;
   @MockBean private UsersApi usersApi;
-  @SpyBean private SamService samService;
+  @MockBean private SamService samService;
   @MockBean private CromwellService cromwellService;
   @MockBean private WdsService wdsService;
   @MockBean private DockstoreService dockstoreService;
@@ -959,6 +963,192 @@ class TestRunSetsApiController {
         parsedResponse.getErrors());
     assertEquals(1, parsedResponse.getRuns().size());
     assertNotSame(CANCELING, run2.status());
+  }
+
+  @Test
+  void returnErrorForUserWithNoReadAccess() throws Exception {
+    when(samService.hasReadPermission()).thenReturn(false);
+
+    mockMvc
+        .perform(get(API))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            result -> assertTrue(result.getResolvedException() instanceof ForbiddenException))
+        .andExpect(
+            result ->
+                assertEquals(
+                    "User doesn't have 'read' permission on 'workspace' resource",
+                    result.getResolvedException().getMessage()));
+  }
+
+  @Test
+  void returnErrorForUserWithNoComputeAccessForPostApi() throws Exception {
+    final String optionalInputSourceString = "{ \"type\" : \"none\", \"record_attribute\" : null }";
+    String request =
+        requestTemplate.formatted(
+            methodVersionId,
+            isCallCachingEnabled,
+            optionalInputSourceString,
+            outputDefinitionAsString,
+            recordType,
+            "[ \"%s\", \"%s\", \"%s\" ]".formatted(recordId1, recordId2, recordId3));
+
+    when(samService.hasComputePermission()).thenReturn(false);
+
+    mockMvc
+        .perform(post(API).content(request).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            result -> assertTrue(result.getResolvedException() instanceof ForbiddenException))
+        .andExpect(
+            result ->
+                assertEquals(
+                    "User doesn't have 'compute' permission on 'workspace' resource",
+                    result.getResolvedException().getMessage()));
+  }
+
+  @Test
+  void returnErrorForUserWithNoComputeAccessForAbortApi() throws Exception {
+    when(samService.hasComputePermission()).thenReturn(false);
+
+    mockMvc
+        .perform(post(API_ABORT).param("run_set_id", UUID.randomUUID().toString()))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            result -> assertTrue(result.getResolvedException() instanceof ForbiddenException))
+        .andExpect(
+            result ->
+                assertEquals(
+                    "User doesn't have 'compute' permission on 'workspace' resource",
+                    result.getResolvedException().getMessage()));
+  }
+
+  @Test
+  void returnErrorForGetRequestWithoutToken() throws Exception {
+    when(samService.hasReadPermission())
+        .thenThrow(
+            new BeanCreationException(
+                "BearerToken bean instantiation failed.",
+                new UnauthorizedException("Authorization header missing")));
+
+    MvcResult response =
+        mockMvc
+            .perform(get(API))
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                result ->
+                    assertTrue(result.getResolvedException() instanceof BeanCreationException))
+            .andReturn();
+
+    // verify that the response object is of type ErrorReport and that the nested Unauthorized
+    // exception was surfaced to user
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Authorization header missing", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForPostRequestWithoutToken() throws Exception {
+    final String optionalInputSourceString = "{ \"type\" : \"none\", \"record_attribute\" : null }";
+    String request =
+        requestTemplate.formatted(
+            methodVersionId,
+            isCallCachingEnabled,
+            optionalInputSourceString,
+            outputDefinitionAsString,
+            recordType,
+            "[ \"%s\", \"%s\", \"%s\" ]".formatted(recordId1, recordId2, recordId3));
+
+    when(samService.hasComputePermission())
+        .thenThrow(
+            new BeanCreationException(
+                "BearerToken bean instantiation failed.",
+                new UnauthorizedException("Authorization header missing")));
+
+    MvcResult response =
+        mockMvc
+            .perform(post(API).content(request).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                result ->
+                    assertTrue(result.getResolvedException() instanceof BeanCreationException))
+            .andReturn();
+
+    // verify that the response object is of type ErrorReport and that the nested Unauthorized
+    // exception was surfaced to user
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Authorization header missing", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForAbortRequestWithoutToken() throws Exception {
+    when(samService.hasComputePermission())
+        .thenThrow(
+            new BeanCreationException(
+                "BearerToken bean instantiation failed.",
+                new UnauthorizedException("Authorization header missing")));
+
+    MvcResult response =
+        mockMvc
+            .perform(post(API_ABORT).param("run_set_id", UUID.randomUUID().toString()))
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                result ->
+                    assertTrue(result.getResolvedException() instanceof BeanCreationException))
+            .andReturn();
+
+    // verify that the response object is of type ErrorReport and that the nested Unauthorized
+    // exception was surfaced to user
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Authorization header missing", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForSamApiException() throws Exception {
+    // throw a form of ErrorReportException which is thrown when an ApiException happens in
+    // hasPermission()
+    when(samService.hasReadPermission())
+        .thenThrow(new SamUnauthorizedException("Exception thrown for testing purposes"));
+
+    MvcResult response = mockMvc.perform(get(API)).andExpect(status().isUnauthorized()).andReturn();
+
+    // verify that the response object is of type ErrorReport and that the exception message is set
+    // properly
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Exception thrown for testing purposes", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForSamInterruptedException() throws Exception {
+    // throw SamInterruptedException which is thrown when InterruptedException happens in
+    // hasPermission()
+    when(samService.hasComputePermission())
+        .thenThrow(new SamInterruptedException("InterruptedException thrown for testing purposes"));
+
+    MvcResult response =
+        mockMvc
+            .perform(post(API_ABORT).param("run_set_id", UUID.randomUUID().toString()))
+            .andExpect(status().isInternalServerError())
+            .andReturn();
+
+    // verify that the response object is of type ErrorReport and that the exception message is set
+    // properly
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(500, errorResponse.getStatusCode());
+    assertEquals("InterruptedException thrown for testing purposes", errorResponse.getMessage());
   }
 }
 

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.cbas.dao.RunDao;
+import bio.terra.cbas.dependencies.sam.SamService;
 import bio.terra.cbas.model.RunLog;
 import bio.terra.cbas.model.RunLogResponse;
 import bio.terra.cbas.models.CbasRunSetStatus;
@@ -34,7 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest
-@ContextConfiguration(classes = RunsApiController.class)
+@ContextConfiguration(classes = {RunsApiController.class, GlobalExceptionHandler.class})
 class TestRunsApiController {
 
   private static final String API = "/api/batch/v1/runs";
@@ -52,6 +53,7 @@ class TestRunsApiController {
   // The object mapper is pulled from the BeanConfig and used to convert to and from JSON in the
   // tests:
   @Autowired private ObjectMapper objectMapper;
+  @MockBean private SamService samService;
 
   private static final UUID returnedRunId = UUID.randomUUID();
   private static final UUID returnedRunEngineId = UUID.randomUUID();
@@ -121,6 +123,7 @@ class TestRunsApiController {
 
   @Test
   void smartPollAndUpdateStatus() throws Exception {
+    when(samService.hasReadPermission()).thenReturn(true);
 
     when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
 

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -3,6 +3,7 @@ package bio.terra.cbas.controllers;
 import static bio.terra.cbas.models.CbasRunStatus.COMPLETE;
 import static bio.terra.cbas.models.CbasRunStatus.RUNNING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
@@ -10,8 +11,10 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dependencies.sam.SamService;
+import bio.terra.cbas.model.ErrorReport;
 import bio.terra.cbas.model.RunLog;
 import bio.terra.cbas.model.RunLogResponse;
 import bio.terra.cbas.models.CbasRunSetStatus;
@@ -22,11 +25,15 @@ import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
 import bio.terra.cbas.monitoring.TimeLimitedUpdater.UpdateResult;
 import bio.terra.cbas.runsets.monitoring.SmartRunsPoller;
+import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.sam.exception.SamInterruptedException;
+import bio.terra.common.sam.exception.SamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -146,5 +153,84 @@ class TestRunsApiController {
     assertEquals("outputDefinition", runLog.getWorkflowOutputs());
     assertEquals(
         CbasRunStatus.toCbasApiState(COMPLETE), parsedResponse.getRuns().get(0).getState());
+  }
+
+  @Test
+  void returnErrorForUserWithNoReadAccess() throws Exception {
+    when(samService.hasReadPermission()).thenReturn(false);
+
+    mockMvc
+        .perform(get(API))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            result -> assertTrue(result.getResolvedException() instanceof ForbiddenException))
+        .andExpect(
+            result ->
+                assertEquals(
+                    "User doesn't have 'read' permission on 'workspace' resource",
+                    result.getResolvedException().getMessage()));
+  }
+
+  @Test
+  void returnErrorForGetRequestWithoutToken() throws Exception {
+    when(samService.hasReadPermission())
+        .thenThrow(
+            new BeanCreationException(
+                "BearerToken bean instantiation failed.",
+                new UnauthorizedException("Authorization header missing")));
+
+    MvcResult response =
+        mockMvc
+            .perform(get(API))
+            .andExpect(status().isUnauthorized())
+            .andExpect(
+                result ->
+                    assertTrue(result.getResolvedException() instanceof BeanCreationException))
+            .andReturn();
+
+    // verify that the response object is of type ErrorReport and that the nested Unauthorized
+    // exception was surfaced to user
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Authorization header missing", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForSamApiException() throws Exception {
+    // throw a form of ErrorReportException which is thrown when an ApiException happens in
+    // hasPermission()
+    when(samService.hasReadPermission())
+        .thenThrow(new SamUnauthorizedException("Exception thrown for testing purposes"));
+
+    MvcResult response = mockMvc.perform(get(API)).andExpect(status().isUnauthorized()).andReturn();
+
+    // verify that the response object is of type ErrorReport and that the exception message is set
+    // properly
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(401, errorResponse.getStatusCode());
+    assertEquals("Exception thrown for testing purposes", errorResponse.getMessage());
+  }
+
+  @Test
+  void returnErrorForSamInterruptedException() throws Exception {
+    // throw SamInterruptedException which is thrown when InterruptedException happens in
+    // hasPermission()
+    when(samService.hasReadPermission())
+        .thenThrow(new SamInterruptedException("InterruptedException thrown for testing purposes"));
+
+    MvcResult response =
+        mockMvc.perform(get(API)).andExpect(status().isInternalServerError()).andReturn();
+
+    // verify that the response object is of type ErrorReport and that the exception message is set
+    // properly
+    ErrorReport errorResponse =
+        objectMapper.readValue(response.getResponse().getContentAsString(), ErrorReport.class);
+
+    assertEquals(500, errorResponse.getStatusCode());
+    assertEquals("InterruptedException thrown for testing purposes", errorResponse.getMessage());
   }
 }

--- a/service/src/test/java/bio/terra/cbas/dependencies/sam/TestSamService.java
+++ b/service/src/test/java/bio/terra/cbas/dependencies/sam/TestSamService.java
@@ -1,21 +1,29 @@
 package bio.terra.cbas.dependencies.sam;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
@@ -24,9 +32,14 @@ class TestSamService {
   @SpyBean private SamService samService;
   @MockBean private BearerToken bearerToken;
 
-  private final String tokenValue = "foo-token";
+  private final String tokenWithCorrectAccess = "foo-token";
+  private final String validTokenWithNoAccess = "foo-no-access-token";
+  private final String validTokenWithReadAccess = "foo-read-access-token";
+  private final String validTokenWithWriteAccess = "foo-write-access-token";
+  private final String validTokenWithComputeAccess = "foo-compute-access-token";
   private final String expiredTokenValue = "expired-token";
   private final String tokenCausingInterrupt = "interrupting-cow-moo";
+  private final String workspaceId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
   private final UserStatusInfo mockUser =
       new UserStatusInfo()
           .userEmail("realuser@gmail.com")
@@ -36,14 +49,23 @@ class TestSamService {
   @BeforeEach
   void init() throws ApiException {
     UsersApi usersApi = mock(UsersApi.class);
+    ResourcesApi resourcesApi = mock(ResourcesApi.class);
     SamClient samClient = mock(SamClient.class);
+    ApiClient apiClient = mock(ApiClient.class);
     samService = spy(new SamService(samClient, bearerToken));
+
+    // setup Sam client methods
+    when(samClient.getApiClient(any())).thenReturn(apiClient);
+    when(samClient.checkAuthAccessWithSam()).thenReturn(true);
+    when(samClient.getWorkspaceId()).thenReturn(workspaceId);
+
     doReturn(usersApi).when(samService).getUsersApi();
     when(usersApi.getUserStatusInfo())
         .thenAnswer(
             (Answer<UserStatusInfo>)
                 invocation -> {
-                  if (bearerToken != null && bearerToken.getToken().equals(tokenValue)) {
+                  if (bearerToken != null
+                      && bearerToken.getToken().equals(tokenWithCorrectAccess)) {
                     return mockUser;
                   } else if (bearerToken != null
                       && bearerToken.getToken().equals(tokenCausingInterrupt)) {
@@ -51,6 +73,74 @@ class TestSamService {
                   } else {
                     // expired or no token
                     throw new ApiException(401, "Unauthorized :(");
+                  }
+                });
+
+    doReturn(resourcesApi).when(samService).getResourcesApi();
+
+    // mock response for hasReadPermission()
+    when(resourcesApi.resourcePermissionV2(any(), any(), eq(samService.READ_ACTION)))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  if (bearerToken != null) {
+                    String token = bearerToken.getToken();
+                    if (token.equals(validTokenWithReadAccess)
+                        || token.equals(validTokenWithWriteAccess)
+                        || token.equals(validTokenWithComputeAccess)) return true;
+                    if (token.equals(validTokenWithNoAccess)) return false;
+                    if (token.equals(tokenCausingInterrupt)) throw new InterruptedException();
+
+                    throw new ApiException(
+                        401, "Unauthorized exception thrown for testing purposes");
+                  } else {
+                    throw new BeanCreationException(
+                        "BearerToken bean throws error when no token is available.",
+                        new UnauthorizedException("Authorization header missing"));
+                  }
+                });
+
+    // mock response for hasWritePermission()
+    when(resourcesApi.resourcePermissionV2(any(), any(), eq(samService.WRITE_ACTION)))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  if (bearerToken != null) {
+                    String token = bearerToken.getToken();
+                    if (token.equals(validTokenWithWriteAccess)
+                        || token.equals(validTokenWithComputeAccess)) return true;
+                    if (token.equals(validTokenWithReadAccess)
+                        || token.equals(validTokenWithNoAccess)) return false;
+                    if (token.equals(tokenCausingInterrupt)) throw new InterruptedException();
+
+                    throw new ApiException(
+                        401, "Unauthorized exception thrown for testing purposes");
+                  } else {
+                    throw new BeanCreationException(
+                        "BearerToken bean throws error when no token is available.",
+                        new UnauthorizedException("Authorization header missing"));
+                  }
+                });
+
+    // mock response for hasComputePermission()
+    when(resourcesApi.resourcePermissionV2(any(), any(), eq(samService.COMPUTE_ACTION)))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  if (bearerToken != null) {
+                    String token = bearerToken.getToken();
+                    if (token.equals(validTokenWithComputeAccess)) return true;
+                    if (token.equals(validTokenWithReadAccess)
+                        || token.equals(validTokenWithWriteAccess)
+                        || token.equals(validTokenWithNoAccess)) return false;
+                    if (token.equals(tokenCausingInterrupt)) throw new InterruptedException();
+
+                    throw new ApiException(
+                        401, "Unauthorized exception thrown for testing purposes");
+                  } else {
+                    throw new BeanCreationException(
+                        "BearerToken bean throws error when no token is available.",
+                        new UnauthorizedException("Authorization header missing"));
                   }
                 });
   }
@@ -61,7 +151,7 @@ class TestSamService {
 
   @Test
   void testGetSamUserValidToken() {
-    setTokenValue(tokenValue);
+    setTokenValue(tokenWithCorrectAccess);
     UserStatusInfo user = samService.getSamUser();
     assertEquals(mockUser, user);
   }
@@ -91,5 +181,111 @@ class TestSamService {
         assertThrows(SamInterruptedException.class, () -> samService.getSamUser());
     assertEquals("Request interrupted while getting user status info from Sam", e.getMessage());
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatusCode());
+  }
+
+  // tests for checking read, write and compute access for a token with only read access
+
+  @Test
+  void testHasReadPermissionForTokenWithReadAccess() {
+    setTokenValue(validTokenWithReadAccess);
+    assertTrue(samService.hasReadPermission());
+  }
+
+  @Test
+  void testHasWritePermissionForTokenWithReadAccess() {
+    setTokenValue(validTokenWithReadAccess);
+    assertFalse(samService.hasWritePermission());
+  }
+
+  @Test
+  void testHasComputePermissionForTokenWithReadAccess() {
+    setTokenValue(validTokenWithReadAccess);
+    assertFalse(samService.hasComputePermission());
+  }
+
+  // tests for checking read, write and compute access for a token with write access
+
+  @Test
+  void testHasReadPermissionForTokenWithWriteAccess() {
+    setTokenValue(validTokenWithWriteAccess);
+    assertTrue(samService.hasReadPermission());
+  }
+
+  @Test
+  void testHasWritePermissionForTokenWithWriteAccess() {
+    setTokenValue(validTokenWithWriteAccess);
+    assertTrue(samService.hasWritePermission());
+  }
+
+  @Test
+  void testHasComputePermissionForTokenWithWriteAccess() {
+    setTokenValue(validTokenWithWriteAccess);
+    assertFalse(samService.hasComputePermission());
+  }
+
+  // tests for checking read, write and compute access for a token with compute access
+
+  @Test
+  void testHasReadPermissionForTokenWithComputeAccess() {
+    setTokenValue(validTokenWithComputeAccess);
+    assertTrue(samService.hasReadPermission());
+  }
+
+  @Test
+  void testHasWritePermissionForTokenWithComputeAccess() {
+    setTokenValue(validTokenWithComputeAccess);
+    assertTrue(samService.hasWritePermission());
+  }
+
+  @Test
+  void testHasComputePermissionForTokenWithComputeAccess() {
+    setTokenValue(validTokenWithComputeAccess);
+    assertTrue(samService.hasComputePermission());
+  }
+
+  // tests for checking read, write and compute access for a valid token with no access to current
+  // workspace
+
+  @Test
+  void testHasReadPermissionForTokenWithNoAccess() {
+    setTokenValue(validTokenWithNoAccess);
+    assertFalse(samService.hasReadPermission());
+  }
+
+  @Test
+  void testHasWritePermissionForTokenWithNoAccess() {
+    setTokenValue(validTokenWithNoAccess);
+    assertFalse(samService.hasWritePermission());
+  }
+
+  @Test
+  void testHasComputePermissionForTokenWithNoAccess() {
+    setTokenValue(validTokenWithNoAccess);
+    assertFalse(samService.hasReadPermission());
+  }
+
+  @Test
+  void testHasPermissionForRequestWithNoToken() {
+    // no token set
+    BeanCreationException exception =
+        assertThrows(BeanCreationException.class, () -> samService.hasReadPermission());
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("BearerToken bean throws error when no token is available."));
+    assertTrue(exception.getRootCause() instanceof UnauthorizedException);
+    assertEquals(exception.getRootCause().getMessage(), "Authorization header missing");
+  }
+
+  @Test
+  void testHasPermissionForInterruptingToken() {
+    setTokenValue(tokenCausingInterrupt);
+    SamInterruptedException exception =
+        assertThrows(SamInterruptedException.class, () -> samService.hasComputePermission());
+    assertEquals(
+        "Request interrupted while checking compute permissions on workspace from Sam",
+        exception.getMessage());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
   }
 }


### PR DESCRIPTION
This PR adds the ability in CBAS to check whether the user has proper permissions to access each endpoint in CBAS by calling Sam's `resourcePermissionV2` API. The appropriate access needed for each API was documented in [WM-2126](https://broadworkbench.atlassian.net/browse/WM-2126). The main logic for this is in `SamService.java` file.

Closes https://broadworkbench.atlassian.net/browse/WM-2125