### PR TITLE
[WM-2178] CBAS ignores unknown properties in request body

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
+++ b/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
@@ -5,7 +5,6 @@ import bio.terra.common.iam.BearerTokenFactory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -28,7 +27,6 @@ public class BeanConfig {
         .registerModule(new JavaTimeModule())
         .setDateFormat(new StdDateFormat())
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT)
-        .enable(SerializationFeature.INDENT_OUTPUT)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }
 

--- a/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
+++ b/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
@@ -27,7 +27,7 @@ public class BeanConfig {
         .registerModule(new Jdk8Module())
         .registerModule(new JavaTimeModule())
         .setDateFormat(new StdDateFormat())
-        .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT)
         .enable(SerializationFeature.INDENT_OUTPUT)
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }

--- a/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
+++ b/service/src/main/java/bio/terra/cbas/config/BeanConfig.java
@@ -3,7 +3,9 @@ package bio.terra.cbas.config;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.BearerTokenFactory;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -25,7 +27,9 @@ public class BeanConfig {
         .registerModule(new Jdk8Module())
         .registerModule(new JavaTimeModule())
         .setDateFormat(new StdDateFormat())
-        .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+        .enable(SerializationFeature.INDENT_OUTPUT)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }
 
   /**

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
 
   jackson:
-    serialization.indent-output: true
+    serialization.indent_output: true
     default-property-inclusion: non_null # this prevents a problem serializing VisaCriterion in openapi where `type` is included a second time with null value
 
   main.banner-mode: off

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
     init:
       mode: always
 
+  jackson:
+    serialization.indent-output: true
+
   main.banner-mode: off
 
   web:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -21,11 +21,6 @@ spring:
     init:
       mode: always
 
-
-  jackson:
-    serialization.indent_output: true
-    default-property-inclusion: non_null # this prevents a problem serializing VisaCriterion in openapi where `type` is included a second time with null value
-
   main.banner-mode: off
 
   web:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -21,8 +21,10 @@ spring:
     init:
       mode: always
 
+
   jackson:
     serialization.indent-output: true
+    default-property-inclusion: non_null # this prevents a problem serializing VisaCriterion in openapi where `type` is included a second time with null value
 
   main.banner-mode: off
 


### PR DESCRIPTION
Disables the `FAIL_ON_UNKNOWN_PROPERTIES` flag on our custom `ObjectMapper` bean. Funnily enough, this is typically disabled by default by Spring, but since we are overriding the ObjectMapper Bean we need to explicitly disable it. Tested locally by firing some `POST /run_sets` requests with `"foo": "bar"` in the request body