### PR TITLE
[WM-2095] User ID in Logs

### DIFF
--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
@@ -90,6 +90,7 @@ public class SamService implements HealthCheck {
 
   // Borrowed from WDS
   public UserStatusInfo getSamUser() throws ErrorReportException {
+    logger.info("Getting sam user");
     if (!samClient.checkAuthAccessWithSam()) {
       return new UserStatusInfo(); // Dummy user for local testing
     }

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -48,6 +49,13 @@ public class SamService implements HealthCheck {
     // don't check auth access with Sam if "sam.checkAuthAccess" is false
     if (!samClient.checkAuthAccessWithSam()) return true;
 
+    /* Associate user id with log context for this thread/request. This will be included with
+    request ID within any logs for the remainder of the request. See
+    https://github.com/DataBiosphere/terra-common-lib/blob/eaaf6217ec0f024afa45aac14d21c8964c0f27c5/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java#L129-L132
+    for details on how this is included in cloud logs, and logback.xml for console logs
+    */
+    MDC.put("user", getSamUser().getUserSubjectId());
+
     logger.debug(
         "Checking Sam permission for '{}' resource and '{}' action type for user on workspace '{}'.",
         RESOURCE_TYPE_WORKSPACE,
@@ -82,6 +90,9 @@ public class SamService implements HealthCheck {
 
   // Borrowed from WDS
   public UserStatusInfo getSamUser() throws ErrorReportException {
+    if (!samClient.checkAuthAccessWithSam()) {
+      return new UserStatusInfo(); // Dummy user for local testing
+    }
     UsersApi usersApi = getUsersApi();
     try {
       return SamRetry.retry(usersApi::getUserStatusInfo);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 logging:
   level.bio.terra.cbas: ${BATCHANALYSIS_LOG_LEVEL:info}
-  pattern.level: '%X{requestId} %5p'
 
 server:
   compression:

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <!--
+  This is the basic spring boot config. See:
+  https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-configure-logback-for-logging
+
+  The console log pattern has been modified from the default to include request ID and user ID if present
+  -->
+  <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint}%replace( %mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -84,6 +84,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -96,7 +97,8 @@ import org.springframework.test.web.servlet.MvcResult;
     classes = {
       RunSetsApiController.class,
       CbasApiConfiguration.class,
-      GlobalExceptionHandler.class
+      GlobalExceptionHandler.class,
+      SamService.class
     })
 class TestRunSetsApiController {
 
@@ -208,7 +210,7 @@ class TestRunSetsApiController {
   @MockBean private BearerToken bearerToken;
   @MockBean private SamClient samClient;
   @MockBean private UsersApi usersApi;
-  @MockBean private SamService samService;
+  @SpyBean private SamService samService;
   @MockBean private CromwellService cromwellService;
   @MockBean private WdsService wdsService;
   @MockBean private DockstoreService dockstoreService;
@@ -325,8 +327,8 @@ class TestRunSetsApiController {
     doReturn(mockUser).when(samService).getSamUser();
 
     // setup Sam permission check to return true
-    when(samService.hasReadPermission()).thenReturn(true);
-    when(samService.hasComputePermission()).thenReturn(true);
+    doReturn(true).when(samService).hasReadPermission();
+    doReturn(true).when(samService).hasComputePermission();
   }
 
   @Test
@@ -341,6 +343,8 @@ class TestRunSetsApiController {
             recordType,
             "[ \"%s\", \"%s\", \"%s\" ]".formatted(recordId1, recordId2, recordId3));
 
+    when(samClient.checkAuthAccessWithSam()).thenReturn(true);
+    doCallRealMethod().when(samService).hasComputePermission();
     doCallRealMethod().when(samService).getSamUser();
     doReturn(usersApi).when(samService).getUsersApi();
     when(usersApi.getUserStatusInfo()).thenThrow(new ApiException(401, "No token provided"));


### PR DESCRIPTION
This PR adds user awareness to the existing logging system. Check the code comment in `SamService.java` for further explanation - it is very similar to how we already include requestId in our logs (though the heavy lifting is done by terra-common-lib there).