### PR TITLE
[WM-2184] Remove brackets from Jira ID

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Fetch Jira ID from commit message
         id: ensure-jira-id
         run: |
-          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '[A-Z][A-Z]+-[0-9]+')
+          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '[A-Z][A-Z]+-[0-9]+' | xargs echo -n | tr '[:space:]' ',')
           [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
           echo ::set-output name=JIRA_ID::${JIRA_ID}
       - name: Checkout current code

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Fetch Jira ID from commit message
         id: ensure-jira-id
         run: |
-          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
+          JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '[A-Z][A-Z]+-[0-9]+')
           [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
           echo ::set-output name=JIRA_ID::${JIRA_ID}
       - name: Checkout current code


### PR DESCRIPTION
CBAS `tag-and-publish` workflow was failing on many PRs with messages like `fatal: '[WM-2095]-cbas-update-0.0.148' is not a valid branch name`. Example [here](https://github.com/DataBiosphere/cbas/actions/runs/5891609214/job/15979029163). Git doesn't like brackets in branch names, so removing the brackets should fix this issue (we can see a successful PR was created [here](https://github.com/broadinstitute/terra-helmfile/pull/4442) when brackets were omitted in the original PR itself)

For anyone curious - this wasn't an issue in cromwhelm because we were making direct commits rather than checking out a branch/PR.

[WM-2095]: https://broadworkbench.atlassian.net/browse/WM-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ