### PR TITLE
[WM-2208] Initialize runs with INITIALIZING state

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ TODO: Complete me! Should be of similar quality to the ECM documentation.
 
 For compliance reasons, all pull requests **must** be submitted with a Jira ID in the pull request title.
 You should include the Jira ID near the beginning of the title for better readability.
-For example: "[WM-1992] add statement to README.md and DEVELOPMENT.md about including Jira IDs in PR titles" 
+For example: "[WM-1992] add statement to README.md and DEVELOPMENT.md about including Jira IDs in PR titles"
 
 If there is more than one relevant ticket, include all of their Jira IDs.
 For example: "WM-1997, WM-2002, WM-2005: Fix for many bugs with the same root cause"
@@ -185,9 +185,10 @@ Then navigate to the Swagger: `http://localhost:8080/swagger-ui.html`
 
 New images are built and pushed automatically each time a PR is merged. Developers may
 want to do this manually in order to test in-development CBAS versions in non-local
-environments. 
+environments.
 
 First, log into GCP using `gcloud auth login`. You need this to authenticate to push the image.
+You may also need to run `gcloud auth configure-docker` prior to pushing the image.
 
 ```
 TAG="my-custom-image-name"

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -8,8 +8,8 @@ import static bio.terra.cbas.common.MetricsUtil.recordRunsSubmittedPerRunSet;
 import static bio.terra.cbas.model.RunSetState.CANCELING;
 import static bio.terra.cbas.model.RunSetState.ERROR;
 import static bio.terra.cbas.model.RunSetState.RUNNING;
+import static bio.terra.cbas.models.CbasRunStatus.INITIALIZING;
 import static bio.terra.cbas.models.CbasRunStatus.SYSTEM_ERROR;
-import static bio.terra.cbas.models.CbasRunStatus.UNKNOWN;
 
 import bio.terra.cbas.api.RunSetsApi;
 import bio.terra.cbas.common.DateUtils;
@@ -484,7 +484,8 @@ public class RunSetsApiController implements RunSetsApi {
             cromwellService.submitWorkflow(rawMethodUrl, workflowInputs, workflowOptionsJson);
 
         runStateResponseList.add(
-            storeRun(runId, workflowResponse.getRunId(), runSet, record.getId(), UNKNOWN, null));
+            storeRun(
+                runId, workflowResponse.getRunId(), runSet, record.getId(), INITIALIZING, null));
       } catch (CoercionException e) {
         String errorMsg =
             String.format(

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -160,7 +160,7 @@ public class SmartRunsPoller {
       recordOutboundApiRequestCompletion("wes/runSummary", getStatusStartNanos, getStatusSuccess);
     }
 
-    CbasRunStatus newStatus = CbasRunStatus.INITIALIZING;
+    CbasRunStatus newStatus = CbasRunStatus.UNKNOWN;
     if (newWorkflowSummary != null) {
       newStatus = CbasRunStatus.fromCromwellStatus(newWorkflowSummary.getStatus());
     }

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -1,9 +1,9 @@
 package bio.terra.cbas.controllers;
 
 import static bio.terra.cbas.models.CbasRunStatus.CANCELING;
+import static bio.terra.cbas.models.CbasRunStatus.INITIALIZING;
 import static bio.terra.cbas.models.CbasRunStatus.RUNNING;
 import static bio.terra.cbas.models.CbasRunStatus.SYSTEM_ERROR;
-import static bio.terra.cbas.models.CbasRunStatus.UNKNOWN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
@@ -410,11 +410,11 @@ class TestRunSetsApiController {
     // check Runs 1 & 3 were successfully submitted
     assertEquals(newRunSetCaptor.getValue().runSetId(), capturedRuns.get(0).getRunSetId());
     assertEquals(cromwellWorkflowId1, capturedRuns.get(0).engineId());
-    assertEquals(UNKNOWN, capturedRuns.get(0).status());
+    assertEquals(INITIALIZING, capturedRuns.get(0).status());
     assertEquals(recordId1, capturedRuns.get(0).recordId());
     assertEquals(newRunSetCaptor.getValue().runSetId(), capturedRuns.get(2).getRunSetId());
     assertEquals(cromwellWorkflowId3, capturedRuns.get(2).engineId());
-    assertEquals(UNKNOWN, capturedRuns.get(2).status());
+    assertEquals(INITIALIZING, capturedRuns.get(2).status());
     assertEquals(recordId3, capturedRuns.get(2).recordId());
     // check Run 2 is in failed state
     assertEquals(newRunSetCaptor.getValue().runSetId(), capturedRuns.get(1).getRunSetId());


### PR DESCRIPTION
Small change proposed to address the rocky UI experience immediately following a workflow submission.
New experience:

https://github.com/DataBiosphere/cbas/assets/67511512/b1d9357c-e634-4fcc-9fcc-f102b6d07e2e
