### PR TITLE
[WM-1792] Submit workflows as batch to Cromwell

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/CbasApiConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CbasApiConfiguration.java
@@ -12,6 +12,7 @@ public class CbasApiConfiguration {
   private int maxSmartPollRunUpdateSeconds;
   private int maxSmartPollRunSetUpdateSeconds;
   private int minSecondsBetweenRunStatusPolls;
+  private int maxWorkflowsInBatch;
 
   public void setRunSetsMaximumRecordIds(int runSetsMaximumRecordIds) {
     this.runSetsMaximumRecordIds = runSetsMaximumRecordIds;
@@ -59,5 +60,13 @@ public class CbasApiConfiguration {
 
   public void setMinSecondsBetweenRunStatusPolls(int minSecondsBetweenRunStatusPolls) {
     this.minSecondsBetweenRunStatusPolls = minSecondsBetweenRunStatusPolls;
+  }
+
+  public int getMaxWorkflowsInBatch() {
+    return maxWorkflowsInBatch;
+  }
+
+  public void setMaxWorkflowsInBatch(int maxWorkflowsInBatch) {
+    this.maxWorkflowsInBatch = maxWorkflowsInBatch;
   }
 }

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -475,8 +475,6 @@ public class RunSetsApiController implements RunSetsApi {
     for (List<RecordResponse> batch :
         Lists.partition(recordResponses, cbasApiConfiguration.getMaxWorkflowsInBatch())) {
 
-      List<WorkflowIdAndStatus> submitWorkflowBatchResponse;
-
       Map<UUID, RecordResponse> requestedIdToRecord =
           batch.stream()
               .map(singleRecord -> Map.entry(uuidSource.generateUUID(), singleRecord))
@@ -547,8 +545,8 @@ public class RunSetsApiController implements RunSetsApi {
       }
 
       try {
-        // Submit the workflow, get its ID and store the Run to database
-        submitWorkflowBatchResponse =
+        // Submit the workflows and store the Runs to database
+        List<WorkflowIdAndStatus> submitWorkflowBatchResponse =
             cromwellService.submitWorkflowBatch(
                 rawMethodUrl, requestedIdToWorkflowInput, workflowOptionsJson);
 

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -53,7 +53,8 @@ import bio.terra.cbas.runsets.types.CoercionException;
 import bio.terra.cbas.util.UuidSource;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import cromwell.client.model.RunId;
+import com.google.common.collect.Lists;
+import cromwell.client.model.WorkflowIdAndStatus;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.time.OffsetDateTime;
@@ -64,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.databiosphere.workspacedata.model.RecordResponse;
 import org.springframework.http.HttpStatus;
@@ -470,49 +472,126 @@ public class RunSetsApiController implements RunSetsApi {
         cromwellService.buildWorkflowOptionsJson(
             Objects.requireNonNullElse(runSet.callCachingEnabled(), true));
 
-    for (RecordResponse record : recordResponses) {
-      RunId workflowResponse;
-      UUID runId = uuidSource.generateUUID();
+    for (List<RecordResponse> batch :
+        Lists.partition(recordResponses, cbasApiConfiguration.getMaxWorkflowsInBatch())) {
+
+      List<WorkflowIdAndStatus> submitWorkflowBatchResponse;
+
+      Map<UUID, RecordResponse> requestedIdToRecord =
+          batch.stream()
+              .map(singleRecord -> Map.entry(uuidSource.generateUUID(), singleRecord))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      Map<UUID, UUID> requestedIdToRunId =
+          requestedIdToRecord.keySet().stream()
+              .map(requestedId -> Map.entry(requestedId, uuidSource.generateUUID()))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       try {
+
         // Build the inputs set from workflow parameter definitions and the fetched record
-        Map<String, Object> workflowInputs =
-            InputGenerator.buildInputs(request.getWorkflowInputDefinitions(), record);
+        Map<UUID, Map<String, Object>> requestedIdToWorkflowInput =
+            requestedIdToRecord.entrySet().stream()
+                .map(
+                    entry -> {
+                      try {
+                        return Map.entry(
+                            entry.getKey(),
+                            InputGenerator.buildInputs(
+                                request.getWorkflowInputDefinitions(), entry.getValue()));
+                      } catch (CoercionException e) {
+                        String errorMsg =
+                            String.format(
+                                "Input generation failed for record %s. Coercion error: %s",
+                                entry.getValue().getId(), e.getMessage());
+                        log.warn(errorMsg, e);
+                        runStateResponseList.add(
+                            storeRun(
+                                requestedIdToRunId.get(entry.getKey()),
+                                null,
+                                runSet,
+                                entry.getValue().getId(),
+                                SYSTEM_ERROR,
+                                errorMsg + e.getMessage()));
+                      } catch (InputProcessingException e) {
+                        log.warn(e.getMessage());
+                        runStateResponseList.add(
+                            storeRun(
+                                requestedIdToRunId.get(entry.getKey()),
+                                null,
+                                runSet,
+                                entry.getValue().getId(),
+                                SYSTEM_ERROR,
+                                e.getMessage()));
+                      }
+                      return null;
+                    })
+                .filter(inputs -> !Objects.isNull(inputs))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // Submit the workflow, get its ID and store the Run to database
-        workflowResponse =
-            cromwellService.submitWorkflow(rawMethodUrl, workflowInputs, workflowOptionsJson);
+        submitWorkflowBatchResponse =
+            cromwellService.submitWorkflowBatch(
+                rawMethodUrl, requestedIdToWorkflowInput, workflowOptionsJson);
 
-        runStateResponseList.add(
-            storeRun(
-                runId, workflowResponse.getRunId(), runSet, record.getId(), INITIALIZING, null));
-      } catch (CoercionException e) {
-        String errorMsg =
-            String.format(
-                "Input generation failed for record %s. Coercion error: %s",
-                record.getId(), e.getMessage());
-        log.warn(errorMsg, e);
-        runStateResponseList.add(
-            storeRun(runId, null, runSet, record.getId(), SYSTEM_ERROR, errorMsg + e.getMessage()));
+        runStateResponseList.addAll(
+            submitWorkflowBatchResponse.stream()
+                .map(
+                    idAndStatus -> {
+                      UUID requestedId = UUID.fromString(idAndStatus.getId());
+                      boolean failedToSubmitRun = idAndStatus.getStatus().equals("Failed");
+                      CbasRunStatus status = failedToSubmitRun ? SYSTEM_ERROR : INITIALIZING;
+                      String errors =
+                          failedToSubmitRun
+                              ? String.format(
+                                  "Cromwell submission failed for Record ID %s.",
+                                  requestedIdToRecord.get(requestedId).getId())
+                              : null;
+                      return storeRun(
+                          requestedIdToRunId.get(requestedId),
+                          requestedId.toString(),
+                          runSet,
+                          requestedIdToRecord.get(requestedId).getId(),
+                          status,
+                          errors);
+                    })
+                .toList());
       } catch (cromwell.client.ApiException e) {
         String errorMsg =
             String.format(
-                "Cromwell submission failed for Record ID %s. ApiException: ", record.getId());
+                "Cromwell submission failed for batch in RunSet %s. ApiException: ",
+                runSet.runSetId());
         log.warn(errorMsg, e);
-        runStateResponseList.add(
-            storeRun(runId, null, runSet, record.getId(), SYSTEM_ERROR, errorMsg + e.getMessage()));
-      } catch (JsonProcessingException e) {
+        runStateResponseList.addAll(
+            requestedIdToRunId.keySet().stream()
+                .map(
+                    requestedId ->
+                        storeRun(
+                            requestedIdToRunId.get(requestedId),
+                            null,
+                            runSet,
+                            requestedIdToRecord.get(requestedId).getId(),
+                            SYSTEM_ERROR,
+                            errorMsg + e.getMessage()))
+                .toList());
+      } catch (IllegalStateException e) {
         // Should be super rare that jackson cannot convert an object to Json...
         String errorMsg =
             String.format(
-                "Failed to convert inputs object to JSON for Record ID %s.", record.getId());
+                "Failed to convert inputs object to JSON for batch in RunSet %s.",
+                runSet.runSetId());
         log.warn(errorMsg, e);
-        runStateResponseList.add(
-            storeRun(runId, null, runSet, record.getId(), SYSTEM_ERROR, errorMsg + e.getMessage()));
-      } catch (InputProcessingException e) {
-        log.warn(e.getMessage());
-        runStateResponseList.add(
-            storeRun(runId, null, runSet, record.getId(), SYSTEM_ERROR, e.getMessage()));
+        runStateResponseList.addAll(
+            requestedIdToRunId.keySet().stream()
+                .map(
+                    requestedId ->
+                        storeRun(
+                            requestedIdToRunId.get(requestedId),
+                            null,
+                            runSet,
+                            requestedIdToRecord.get(requestedId).getId(),
+                            SYSTEM_ERROR,
+                            errorMsg + e.getMessage()))
+                .toList());
       }
     }
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -50,6 +50,7 @@ cbas:
     minSecondsBetweenRunStatusPolls: 30
     maxSmartPollRunUpdateSeconds: 3
     maxSmartPollRunSetUpdateSeconds: 6
+    maxWorkflowsInBatch: 100
   scheduler:
     # How often to check downstream services for health:
     healthCheckIntervalSeconds: 300

--- a/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
@@ -34,6 +34,7 @@ import bio.terra.cbas.util.UuidSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cromwell.client.model.RunId;
 import cromwell.client.model.WorkflowDescription;
+import cromwell.client.model.WorkflowIdAndStatus;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
@@ -175,13 +176,16 @@ class VerifyPactsAllControllers {
   public HashMap<String, String> initializeOneRunSet() throws Exception {
     String fixedRunSetUUID = "11111111-1111-1111-1111-111111111111";
     String fixedRunUUID = "22222222-2222-2222-2222-222222222222";
+    String fixedCromwellRunUUID = "33333333-3333-3333-3333-333333333333";
     when(uuidSource.generateUUID())
         .thenReturn(UUID.fromString(fixedRunSetUUID))
+        .thenReturn(UUID.fromString(fixedCromwellRunUUID))
         .thenReturn(UUID.fromString(fixedRunUUID));
 
     RunId myRunId = new RunId();
     myRunId.setRunId(fixedRunUUID);
-    when(cromwellService.submitWorkflow(any(), any(), any())).thenReturn(myRunId);
+    when(cromwellService.submitWorkflowBatch(any(), any(), any()))
+        .thenReturn(List.of(new WorkflowIdAndStatus().id(fixedCromwellRunUUID)));
     when(samService.getSamUser())
         .thenReturn(
             new UserStatusInfo().userEmail("foo-email").userSubjectId("bar-id").enabled(true));

--- a/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
@@ -32,7 +32,6 @@ import bio.terra.cbas.runsets.monitoring.RunSetAbortManager.AbortRequestDetails;
 import bio.terra.cbas.runsets.monitoring.SmartRunSetsPoller;
 import bio.terra.cbas.util.UuidSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import cromwell.client.model.RunId;
 import cromwell.client.model.WorkflowDescription;
 import cromwell.client.model.WorkflowIdAndStatus;
 import java.time.OffsetDateTime;
@@ -64,6 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestPropertySource(properties = "cbas.cbas-api.runSetsMaximumRecordIds=100")
 @TestPropertySource(properties = "cbas.cbas-api.maxWorkflowInputs=100")
 @TestPropertySource(properties = "cbas.cbas-api.maxWorkflowOutputs=40")
+@TestPropertySource(properties = "cbas.cbas-api.maxWorkflowsInBatch=100")
 @Provider("cbas")
 @PactBroker()
 class VerifyPactsAllControllers {
@@ -182,8 +182,6 @@ class VerifyPactsAllControllers {
         .thenReturn(UUID.fromString(fixedCromwellRunUUID))
         .thenReturn(UUID.fromString(fixedRunUUID));
 
-    RunId myRunId = new RunId();
-    myRunId.setRunId(fixedRunUUID);
     when(cromwellService.submitWorkflowBatch(any(), any(), any()))
         .thenReturn(List.of(new WorkflowIdAndStatus().id(fixedCromwellRunUUID)));
     when(samService.getSamUser())


### PR DESCRIPTION
For timing comparison, ran `fetch_sra_to_bam` with 100 workflows with the current version of CBAS and with a version built from this branch:
- current/individual submissions: ~45 seconds for network response
- new/batched submissions: ~16 seconds for network response