### PR TITLE
WM-2123: Request callback in submissions to Cromwell

### DIFF
--- a/service/src/main/java/bio/terra/cbas/config/CbasNetworkConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CbasNetworkConfiguration.java
@@ -1,0 +1,28 @@
+package bio.terra.cbas.config;
+
+import java.util.Optional;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "cbas.network")
+public class CbasNetworkConfiguration {
+
+  public String externalUri;
+
+  public Optional<String> getCallbackUri() {
+    if (externalUri == null || externalUri.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(externalUri + "api/batch/v1/runs/results");
+    }
+  }
+
+  public String getExternalUri() {
+    return externalUri;
+  }
+
+  public void setExternalUri(String externalUri) {
+    this.externalUri = externalUri;
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/config/CbasNetworkConfiguration.java
+++ b/service/src/main/java/bio/terra/cbas/config/CbasNetworkConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "cbas.network")
 public class CbasNetworkConfiguration {
 
-  public String externalUri;
+  private String externalUri;
 
   public Optional<String> getCallbackUri() {
     if (externalUri == null || externalUri.isEmpty()) {

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -82,6 +82,11 @@ public class RunsApiController implements RunsApi {
     // validate request
     UUID runId = body.getWorkflowId();
     CbasRunStatus resultsStatus = CbasRunStatus.fromCromwellStatus(body.getState().toString());
+
+    log.info(
+        "Processing workflow callback for run ID %s with status %s."
+            .formatted(runId, resultsStatus));
+
     if (!resultsStatus.isTerminal()) {
       // only terminal status can be reported
       throw new InvalidStatusTypeException(

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -813,7 +813,7 @@ class TestRunSetsApiController {
         new DependencyUrlLoader(leonardoService, appUtils, leonardoServerConfiguration);
     CromwellClient localTestClient = new CromwellClient(localTestConfig, dependencyUrlLoader);
     CbasNetworkConfiguration cbasNetworkConfiguration = new CbasNetworkConfiguration();
-    cbasNetworkConfiguration.setExternalUri("http://localhost:8080");
+    cbasNetworkConfiguration.setExternalUri("http://localhost:8080/");
     CromwellService localtestService =
         new CromwellService(localTestClient, cromwellClient, cbasNetworkConfiguration);
 
@@ -821,10 +821,10 @@ class TestRunSetsApiController {
     // write_to_cache should always be true. read_from_cache should match the provided call caching
     // option.
     String expected =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"workflow_callback_uri\":\"http://localhost:8080/api/batch/v1/runs/results\",\"write_to_cache\":true}";
     assertEquals(expected, localtestService.buildWorkflowOptionsJson(true));
     String expectedFalse =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"workflow_callback_uri\":\"http://localhost:8080/api/batch/v1/runs/results\",\"write_to_cache\":true}";
     assertEquals(expectedFalse, localtestService.buildWorkflowOptionsJson(false));
 
     // Test that the workflow options are properly constructed when the external uri is not set.

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -835,30 +835,6 @@ class TestRunSetsApiController {
   }
 
   @Test
-  void testResilientToMissingExternalUri() {
-    CromwellServerConfiguration localTestConfig =
-        new CromwellServerConfiguration("my/base/uri", null, "my/final/workflow/log/dir", false);
-    var leonardoServerConfiguration =
-        new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
-    DependencyUrlLoader dependencyUrlLoader =
-        new DependencyUrlLoader(leonardoService, appUtils, leonardoServerConfiguration);
-    CromwellClient localTestClient = new CromwellClient(localTestConfig, dependencyUrlLoader);
-    CbasNetworkConfiguration cbasNetworkConfiguration = new CbasNetworkConfiguration();
-    CromwellService localtestService =
-        new CromwellService(localTestClient, cromwellClient, cbasNetworkConfiguration);
-
-    // Workflow options should reflect the final workflow log directory.
-    // write_to_cache should always be true. read_from_cache should match the provided call caching
-    // option.
-    String expected =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
-    assertEquals(expected, localtestService.buildWorkflowOptionsJson(true));
-    String expectedFalse =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
-    assertEquals(expectedFalse, localtestService.buildWorkflowOptionsJson(false));
-  }
-
-  @Test
   void getRunSetsApiTest() throws Exception {
     RunSet returnedRunSet1 =
         new RunSet(

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.config.CbasApiConfiguration;
+import bio.terra.cbas.config.CbasNetworkConfiguration;
 import bio.terra.cbas.config.CromwellServerConfiguration;
 import bio.terra.cbas.config.LeonardoServerConfiguration;
 import bio.terra.cbas.dao.MethodDao;
@@ -811,16 +812,49 @@ class TestRunSetsApiController {
     DependencyUrlLoader dependencyUrlLoader =
         new DependencyUrlLoader(leonardoService, appUtils, leonardoServerConfiguration);
     CromwellClient localTestClient = new CromwellClient(localTestConfig, dependencyUrlLoader);
-    CromwellService localtestService = new CromwellService(localTestClient, cromwellClient);
+    CbasNetworkConfiguration cbasNetworkConfiguration = new CbasNetworkConfiguration();
+    cbasNetworkConfiguration.setExternalUri("http://localhost:8080");
+    CromwellService localtestService =
+        new CromwellService(localTestClient, cromwellClient, cbasNetworkConfiguration);
 
     // Workflow options should reflect the final workflow log directory.
     // write_to_cache should always be true. read_from_cache should match the provided call caching
     // option.
     String expected =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"write_to_cache\":true}";
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
     assertEquals(expected, localtestService.buildWorkflowOptionsJson(true));
     String expectedFalse =
-        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"write_to_cache\":true}";
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
+    assertEquals(expectedFalse, localtestService.buildWorkflowOptionsJson(false));
+
+    // Test that the workflow options are properly constructed when the external uri is not set.
+    cbasNetworkConfiguration.setExternalUri(null);
+    String expectedNoExternalUri =
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"write_to_cache\":true}";
+    assertEquals(expectedNoExternalUri, localtestService.buildWorkflowOptionsJson(true));
+  }
+
+  @Test
+  void testResilientToMissingExternalUri() {
+    CromwellServerConfiguration localTestConfig =
+        new CromwellServerConfiguration("my/base/uri", null, "my/final/workflow/log/dir", false);
+    var leonardoServerConfiguration =
+        new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
+    DependencyUrlLoader dependencyUrlLoader =
+        new DependencyUrlLoader(leonardoService, appUtils, leonardoServerConfiguration);
+    CromwellClient localTestClient = new CromwellClient(localTestConfig, dependencyUrlLoader);
+    CbasNetworkConfiguration cbasNetworkConfiguration = new CbasNetworkConfiguration();
+    CromwellService localtestService =
+        new CromwellService(localTestClient, cromwellClient, cbasNetworkConfiguration);
+
+    // Workflow options should reflect the final workflow log directory.
+    // write_to_cache should always be true. read_from_cache should match the provided call caching
+    // option.
+    String expected =
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":true,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
+    assertEquals(expected, localtestService.buildWorkflowOptionsJson(true));
+    String expectedFalse =
+        "{\"final_workflow_log_dir\":\"my/final/workflow/log/dir\",\"read_from_cache\":false,\"workflow_callback_uri\":\"http://localhost:8080api/batch/v1/runs/results\",\"write_to_cache\":true}";
     assertEquals(expectedFalse, localtestService.buildWorkflowOptionsJson(false));
   }
 


### PR DESCRIPTION
Adds an additional workflow option to activate workflow completion callbacks (see https://github.com/broadinstitute/cromwell/pull/7213/files under `docs/cromwell_features/WorkflowCallback.md`).

Note: doesn't start doing until without also having:
- [X] Merging of https://github.com/broadinstitute/cromwell/pull/7213
- [ ] Terra-helmfile [changes](https://github.com/broadinstitute/terra-helmfile/pull/4634) to set up callback config in CBAS and in Cromwell Runner