### PR TITLE
[WM-2253] Use HTTP 1.1 for sam client

### DIFF
--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
@@ -2,8 +2,10 @@ package bio.terra.cbas.dependencies.sam;
 
 import bio.terra.cbas.config.SamServerConfiguration;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.springframework.stereotype.Component;
+import java.util.List;
 
 @Component
 public class SamClient {
@@ -13,7 +15,7 @@ public class SamClient {
 
   public SamClient(SamServerConfiguration samServerConfiguration) {
     this.samServerConfiguration = samServerConfiguration;
-    this.singletonHttpClient = new ApiClient().getHttpClient();
+    this.singletonHttpClient = new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
   }
 
   public ApiClient getApiClient() {

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamClient.java
@@ -1,11 +1,11 @@
 package bio.terra.cbas.dependencies.sam;
 
 import bio.terra.cbas.config.SamServerConfiguration;
+import java.util.List;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.springframework.stereotype.Component;
-import java.util.List;
 
 @Component
 public class SamClient {
@@ -15,7 +15,8 @@ public class SamClient {
 
   public SamClient(SamServerConfiguration samServerConfiguration) {
     this.samServerConfiguration = samServerConfiguration;
-    this.singletonHttpClient = new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
+    this.singletonHttpClient =
+        new ApiClient().getHttpClient().newBuilder().protocols(List.of(Protocol.HTTP_1_1)).build();
   }
 
   public ApiClient getApiClient() {


### PR DESCRIPTION
![image](https://github.com/DataBiosphere/cbas/assets/67511512/617f02d1-8f2d-44fa-a986-24234ab68c2c)

Utilizing the same fix for the above as https://github.com/broadinstitute/rawls/pull/2154, which was reported [here](https://broadworkbench.atlassian.net/browse/WOR-641?focusedCommentId=72249) to resolve the issue. Does not seem to be related to access token issues, as logs and subsequent calls with the same token were successful.