### PR TITLE
[WM-2254] Workflow completion callback hitting run not found exception

### DIFF
--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -90,8 +90,7 @@ public class RunsApiController implements RunsApi {
     }
 
     // lookup runID in database
-    Optional<Run> runRecord =
-        runDao.getRuns(new RunDao.RunsFilters(runId, null)).stream().findFirst();
+    Optional<Run> runRecord = runDao.getRunByIdIfExists(runId);
     if (!runRecord.isPresent()) {
       throw new RunNotFoundException("Workflow ID %s is not found.".formatted(runId));
     }

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -85,7 +85,7 @@ public class RunsApiController implements RunsApi {
 
     log.info(
         "Processing workflow callback for run ID %s with status %s."
-            .formatted(runId, resultsStatus));
+            .formatted(engineId, resultsStatus));
 
     if (!resultsStatus.isTerminal()) {
       // only terminal status can be reported

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -199,6 +199,11 @@ public class RunDao {
   public record StatusCountRecord(
       CbasRunStatus status, Integer count, OffsetDateTime lastModified) {}
 
+  public int deleteRun(UUID runId) {
+    return jdbcTemplate.update(
+        "DELETE FROM run WHERE run_id = :run_id", new MapSqlParameterSource(Run.RUN_ID_COL, runId));
+  }
+
   private static class StatusCountMapper implements RowMapper<StatusCountRecord> {
     public StatusCountRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new StatusCountRecord(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -125,4 +125,10 @@ public class RunSetDao {
     String sql = updateClause + " WHERE %s = :run_set_id".formatted(RunSet.RUN_SET_ID_COL);
     return jdbcTemplate.update(sql, new MapSqlParameterSource(parameterMap));
   }
+
+  public int deleteRunSets(UUID runSetId) {
+    return jdbcTemplate.update(
+        "DELETE FROM run_set WHERE run_set_id = :run_set_id",
+        new MapSqlParameterSource(RunSet.RUN_SET_ID_COL, runSetId));
+  }
 }

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,7 +66,6 @@ import bio.terra.cbas.runsets.monitoring.RunSetAbortManager.AbortRequestDetails;
 import bio.terra.cbas.runsets.monitoring.SmartRunSetsPoller;
 import bio.terra.cbas.util.UuidSource;
 import bio.terra.common.exception.UnauthorizedException;
-import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import bio.terra.dockstore.model.ToolDescriptor;
@@ -75,9 +75,9 @@ import cromwell.client.model.WorkflowIdAndStatus;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -222,7 +222,6 @@ class TestRunSetsApiController {
   // later):
   @MockBean private SamClient samClient;
   @MockBean private UsersApi usersApi;
-  @MockBean private BearerToken bearerToken;
   @MockBean private ApiClient cromwellClient;
   @SpyBean private SamService samService;
   @MockBean private CromwellService cromwellService;
@@ -260,16 +259,6 @@ class TestRunSetsApiController {
     RecordAttributes recordAttributes3 = new RecordAttributes();
     recordAttributes3.put(recordAttribute, recordAttributeValue3);
     recordAttributes3.put(recordAttribute2, recordAttributeValue3);
-
-    HashMap<String, Object> workflowInputsMap1 = new HashMap<>();
-    workflowInputsMap1.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap1.put("myworkflow.mycall.inputname2", 100L);
-    HashMap<String, Object> workflowInputsMap2 = new HashMap<>();
-    workflowInputsMap2.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap2.put("myworkflow.mycall.inputname2", 200L);
-    HashMap<String, Object> workflowInputsMap3 = new HashMap<>();
-    workflowInputsMap3.put("myworkflow.mycall.inputname1", "literal value");
-    workflowInputsMap3.put("myworkflow.mycall.inputname2", 300L);
 
     ToolDescriptor mockToolDescriptor = new ToolDescriptor();
     mockToolDescriptor.setDescriptor("mock descriptor");
@@ -390,7 +379,7 @@ class TestRunSetsApiController {
             result ->
                 assertEquals(
                     "Error getting user status info from Sam: No token provided",
-                    result.getResolvedException().getMessage()));
+                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
   }
 
   @Test
@@ -417,6 +406,7 @@ class TestRunSetsApiController {
     RunSetStateResponse response =
         objectMapper.readValue(
             result.getResponse().getContentAsString(), RunSetStateResponse.class);
+    assertNotNull(response);
 
     ArgumentCaptor<RunSet> newRunSetCaptor = ArgumentCaptor.forClass(RunSet.class);
     verify(runSetDao).createRunSet(newRunSetCaptor.capture());
@@ -490,6 +480,7 @@ class TestRunSetsApiController {
     RunSetStateResponse response =
         objectMapper.readValue(
             result.getResponse().getContentAsString(), RunSetStateResponse.class);
+    assertNotNull(response);
 
     ArgumentCaptor<RunSet> newRunSetCaptor = ArgumentCaptor.forClass(RunSet.class);
     verify(runSetDao).createRunSet(newRunSetCaptor.capture());
@@ -685,6 +676,7 @@ class TestRunSetsApiController {
     RunSetStateResponse responseOptionalNone =
         objectMapper.readValue(
             resultOptionalNone.getResponse().getContentAsString(), RunSetStateResponse.class);
+    assertNotNull(responseOptionalNone);
   }
 
   @Test
@@ -713,6 +705,7 @@ class TestRunSetsApiController {
         objectMapper.readValue(
             resultOptionalRecordLookup.getResponse().getContentAsString(),
             RunSetStateResponse.class);
+    assertNotNull(responseOptionalRecordLookup);
   }
 
   @Test
@@ -738,6 +731,7 @@ class TestRunSetsApiController {
     RunSetStateResponse responseOptionalLiteral =
         objectMapper.readValue(
             resultOptionalLiteral.getResponse().getContentAsString(), RunSetStateResponse.class);
+    assertNotNull(responseOptionalLiteral);
   }
 
   @Test
@@ -1105,7 +1099,7 @@ class TestRunSetsApiController {
             result ->
                 assertEquals(
                     "User doesn't have 'read' permission on 'workspace' resource",
-                    result.getResolvedException().getMessage()));
+                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
   }
 
   @Test
@@ -1131,7 +1125,7 @@ class TestRunSetsApiController {
             result ->
                 assertEquals(
                     "User doesn't have 'compute' permission on 'workspace' resource",
-                    result.getResolvedException().getMessage()));
+                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
   }
 
   @Test
@@ -1147,7 +1141,7 @@ class TestRunSetsApiController {
             result ->
                 assertEquals(
                     "User doesn't have 'compute' permission on 'workspace' resource",
-                    result.getResolvedException().getMessage()));
+                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -67,6 +67,7 @@ import bio.terra.cbas.runsets.monitoring.RunSetAbortManager.AbortRequestDetails;
 import bio.terra.cbas.runsets.monitoring.SmartRunSetsPoller;
 import bio.terra.cbas.util.UuidSource;
 import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import bio.terra.dockstore.model.ToolDescriptor;
@@ -223,6 +224,7 @@ class TestRunSetsApiController {
   // later):
   @MockBean private SamClient samClient;
   @MockBean private UsersApi usersApi;
+  @MockBean private BearerToken bearerToken;
   @MockBean private ApiClient cromwellClient;
   @SpyBean private SamService samService;
   @MockBean private CromwellService cromwellService;

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -37,8 +37,8 @@ import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
@@ -248,7 +248,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsSuccessOnTerminalStatus() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(COMPLETE), any(), any()))
         .thenReturn(RunCompletionResult.SUCCESS);
 
@@ -273,7 +273,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnSystemErrorWhenUpdateThrows() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenThrow(new RuntimeException("Failed to connect to database"));
 
@@ -295,7 +295,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnSystemErrorWhenUpdateErrors() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenReturn(RunCompletionResult.ERROR);
 
@@ -319,7 +319,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsSuccessWhenUserHasNoPermission() throws Exception {
     when(samService.hasWritePermission()).thenReturn(false);
-    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenReturn(RunCompletionResult.SUCCESS);
 
@@ -341,7 +341,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsUserErrorWhenRunIdNotFound() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRuns(any())).thenReturn(Collections.emptyList());
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.empty());
     var requestBody =
         new RunResultsRequest()
             .workflowId(updatedRun.runId())
@@ -364,7 +364,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsUserErrorWhenMissingOutputs() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
     var requestBody =
         new RunResultsRequest()
             .workflowId(updatedRun.runId())

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -37,8 +37,9 @@ import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
@@ -179,7 +180,7 @@ class TestRunsApiController {
             result ->
                 assertEquals(
                     "User doesn't have 'read' permission on 'workspace' resource",
-                    result.getResolvedException().getMessage()));
+                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
   }
 
   @Test
@@ -248,7 +249,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsSuccessOnTerminalStatus() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(COMPLETE), any(), any()))
         .thenReturn(RunCompletionResult.SUCCESS);
 
@@ -273,7 +274,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnSystemErrorWhenUpdateThrows() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenThrow(new RuntimeException("Failed to connect to database"));
 
@@ -295,7 +296,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnSystemErrorWhenUpdateErrors() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenReturn(RunCompletionResult.ERROR);
 
@@ -319,7 +320,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsSuccessWhenUserHasNoPermission() throws Exception {
     when(samService.hasWritePermission()).thenReturn(false);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
     when(runsResultsManager.updateResults(any(), eq(CbasRunStatus.SYSTEM_ERROR), any(), any()))
         .thenReturn(RunCompletionResult.SUCCESS);
 
@@ -341,7 +342,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsUserErrorWhenRunIdNotFound() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.empty());
+    when(runDao.getRuns(any())).thenReturn(Collections.emptyList());
     var requestBody =
         new RunResultsRequest()
             .workflowId(updatedRun.runId())
@@ -364,7 +365,7 @@ class TestRunsApiController {
   @Test
   void runResultsUpdateReturnsUserErrorWhenMissingOutputs() throws Exception {
     when(samService.hasWritePermission()).thenReturn(true);
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(returnedRun));
+    when(runDao.getRuns(any())).thenReturn(List.of(returnedRun));
     var requestBody =
         new RunResultsRequest()
             .workflowId(updatedRun.runId())

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -28,8 +28,8 @@ class TestRunDao {
   Method method =
       new Method(
           UUID.randomUUID(),
-          "fetch_sra_to_bam",
-          "fetch_sra_to_bam",
+          "fetch_sra_to_bam_run_test",
+          "fetch_sra_to_bam_run_test",
           OffsetDateTime.parse("2023-01-27T19:21:24.563932Z"),
           null,
           "Github");
@@ -48,8 +48,8 @@ class TestRunDao {
       new RunSet(
           UUID.randomUUID(),
           methodVersion,
-          "fetch_sra_to_bam workflow",
-          "fetch_sra_to_bam sample submission",
+          "fetch_sra_to_bam_run_test workflow",
+          "fetch_sra_to_bam_run_test sample submission",
           false,
           true,
           CbasRunSetStatus.RUNNING,

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -123,8 +123,8 @@ class TestRunDao {
         int runsDeleted = runDao.deleteRun(run.runId());
         int runSetsDeleted = runSetDao.deleteRunSets(runSet.runSetId());
 
-        assertEquals(runsDeleted, 1);
-        assertEquals(runSetsDeleted, 1);
+        assertEquals(1, runsDeleted);
+        assertEquals(1, runSetsDeleted);
       } catch (Exception ex) {
         fail("Failure while removing test run from a database", ex);
       }
@@ -155,8 +155,8 @@ class TestRunDao {
         int runsDeleted = runDao.deleteRun(run.runId());
         int runSetsDeleted = runSetDao.deleteRunSets(runSet.runSetId());
 
-        assertEquals(runsDeleted, 1);
-        assertEquals(runSetsDeleted, 1);
+        assertEquals(1, runsDeleted);
+        assertEquals(1, runSetsDeleted);
       } catch (Exception ex) {
         fail("Failure while removing test run from a database", ex);
       }
@@ -177,8 +177,8 @@ class TestRunDao {
         int runsDeleted = runDao.deleteRun(run.runId());
         int runSetsDeleted = runSetDao.deleteRunSets(runSet.runSetId());
 
-        assertEquals(runsDeleted, 1);
-        assertEquals(runSetsDeleted, 1);
+        assertEquals(1, runsDeleted);
+        assertEquals(1, runSetsDeleted);
       } catch (Exception ex) {
         fail("Failure while removing test run from a database", ex);
       }

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -137,7 +137,8 @@ class TestRunDao {
       runSetDao.createRunSet(runSet);
       runDao.createRun(run);
 
-      List<Run> result = runDao.getRuns(new RunDao.RunsFilters(run.runSet().runSetId(), null, run.engineId()));
+      List<Run> result =
+          runDao.getRuns(new RunDao.RunsFilters(run.runSet().runSetId(), null, run.engineId()));
       assertNotNull(result);
       assertEquals(1, (long) result.size());
       assertTrue(result.stream().findFirst().isPresent());

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.Method;
@@ -9,6 +10,7 @@ import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -66,6 +68,22 @@ class TestRunSetDao {
     methodDao.createMethod(method);
     methodVersionDao.createMethodVersion(methodVersion);
     runSetDao.createRunSet(runSet);
+  }
+
+  @AfterAll
+  void cleanup() {
+    try {
+      int recordsRunSetDeleted = runSetDao.deleteRunSets(runSet.runSetId());
+      int recordsMethodVersionDeleted =
+          methodVersionDao.deleteMethodVersion(methodVersion.methodVersionId());
+      int recordsMethodDeleted = methodDao.deleteMethod(method.methodId());
+
+      assertEquals(1, recordsRunSetDeleted);
+      assertEquals(1, recordsMethodDeleted);
+      assertEquals(1, recordsMethodVersionDeleted);
+    } catch (Exception ex) {
+      fail("Failure while removing test run set record from a database", ex);
+    }
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
@@ -1,0 +1,142 @@
+package bio.terra.cbas.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cbas.dao.RunDao.RunsFilters;
+import bio.terra.cbas.dao.util.WhereClause;
+import bio.terra.cbas.models.CbasRunStatus;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestRunsFilters {
+
+  // Sort the NON_TERMINAL_STATES so that we can guarantee the order (based on enum ordination):
+  // UNKNOWN, QUEUED, INITIALIZING, RUNNING, PAUSED, CANCELING
+  private static final List<CbasRunStatus> sortedNonTerminalStatuses =
+      CbasRunStatus.NON_TERMINAL_STATES.stream().sorted().toList();
+
+  @Test
+  void emptyRunFilters() {
+    RunsFilters filters = RunsFilters.empty();
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void emptyRunFilters2() {
+    RunsFilters filters = new RunsFilters(null, null);
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void emptyRunFilters3() {
+    RunsFilters filters = new RunsFilters(null, List.of());
+    assertEquals(new WhereClause(List.of(), Map.of()), filters.buildWhereClause());
+  }
+
+  @Test
+  void runSetId() {
+    UUID uuid = UUID.randomUUID();
+    RunsFilters filters = new RunsFilters(uuid, null);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals("WHERE (run.run_set_id = :runSetId)", actual.toString());
+    assertEquals(Map.of("runSetId", uuid), actual.params());
+  }
+
+  @Test
+  void filterSortedNonTerminalStates() {
+
+    RunsFilters filters = new RunsFilters(null, sortedNonTerminalStatuses);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals(
+        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+    assertEquals(
+        Map.of(
+            "status_0", "UNKNOWN",
+            "status_1", "QUEUED",
+            "status_2", "INITIALIZING",
+            "status_3", "RUNNING",
+            "status_4", "PAUSED",
+            "status_5", "CANCELING"),
+        actual.params());
+  }
+
+  @Test
+  void filterRawNonTerminalStates() {
+
+    // Unsorted NON_TERMINAL_STATES is the more likely use case.
+    RunsFilters filters = new RunsFilters(null, CbasRunStatus.NON_TERMINAL_STATES);
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals(
+        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+
+    // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
+    // placeholder,
+    // but we can make sure all the right keys and values are in the map in SOME order...
+    assertEquals(
+        CbasRunStatus.NON_TERMINAL_STATES.stream()
+            .map(CbasRunStatus::toString)
+            .collect(Collectors.toSet()),
+        new HashSet<>(actual.params().values()));
+    assertEquals(
+        Set.of("status_0", "status_1", "status_2", "status_3", "status_4", "status_5"),
+        actual.params().keySet());
+  }
+
+  @Test
+  void filterRunSetIdAndSortedNonTerminalStatuses() {
+    UUID uuid = UUID.randomUUID();
+    RunsFilters filters = new RunsFilters(uuid, sortedNonTerminalStatuses);
+    WhereClause actual = filters.buildWhereClause();
+
+    assertEquals(
+        "WHERE (run.run_set_id = :runSetId) AND (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5))",
+        actual.toString());
+    assertEquals(
+        Map.of(
+            "runSetId", uuid,
+            "status_0", "UNKNOWN",
+            "status_1", "QUEUED",
+            "status_2", "INITIALIZING",
+            "status_3", "RUNNING",
+            "status_4", "PAUSED",
+            "status_5", "CANCELING"),
+        actual.params());
+  }
+
+  @Test
+  void truncateTooShortMessage() {
+    String message = "This is a short message";
+    String actual = RunDao.truncatedErrorMessage(message);
+    assertEquals(message, actual);
+    assertEquals(23, actual.length());
+  }
+
+  @Test
+  void truncateExactLengthMessage() {
+
+    String inputString = "a".repeat(1000);
+    String actual = RunDao.truncatedErrorMessage(inputString);
+
+    assertEquals(inputString, actual);
+    assertEquals(1000, actual.length());
+  }
+
+  @Test
+  void truncateTooLongMessage() {
+
+    String inputString = "a".repeat(1025);
+    String expectedString = "a".repeat(1000);
+
+    String actual = RunDao.truncatedErrorMessage(inputString);
+
+    assertEquals(expectedString, actual);
+    assertEquals(1000, actual.length());
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
@@ -105,6 +105,29 @@ class TestRunsFilters {
   }
 
   @Test
+  void filterRawNonTerminalStatesAndEngineId() {
+
+    // Unsorted NON_TERMINAL_STATES is the more likely use case.
+    RunsFilters filters = new RunsFilters(null, CbasRunStatus.NON_TERMINAL_STATES, "engineId_1");
+    WhereClause actual = filters.buildWhereClause();
+    assertEquals(
+        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5)) AND (run.engine_id = :engineId)",
+        actual.toString());
+
+    // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
+    // placeholder,
+    // but we can make sure all the right keys and values are in the map in SOME order...
+    assertEquals(
+        CbasRunStatus.NON_TERMINAL_STATES.stream()
+            .map(CbasRunStatus::toString)
+            .collect(Collectors.toSet()),
+        new HashSet<>(actual.params().values()));
+    assertEquals(
+        Set.of("status_0", "status_1", "status_2", "status_3", "status_4", "status_5", "engine_id"),
+        actual.params().keySet());
+  }
+
+  @Test
   void filterRunSetIdAndSortedNonTerminalStatuses() {
     UUID uuid = UUID.randomUUID();
     RunsFilters filters = new RunsFilters(uuid, sortedNonTerminalStatuses);

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cbas.dao.RunDao.RunsFilters;
 import bio.terra.cbas.dao.util.WhereClause;
@@ -114,17 +115,8 @@ class TestRunsFilters {
         "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5)) AND (run.engine_id = :engineId)",
         actual.toString());
 
-    // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
-    // placeholder,
-    // but we can make sure all the right keys and values are in the map in SOME order...
-    assertEquals(
-        CbasRunStatus.NON_TERMINAL_STATES.stream()
-            .map(CbasRunStatus::toString)
-            .collect(Collectors.toSet()),
-        new HashSet<>(actual.params().values()));
-    assertEquals(
-        Set.of("status_0", "status_1", "status_2", "status_3", "status_4", "status_5", "engine_id"),
-        actual.params().keySet());
+    assertTrue(actual.params().values().contains("engineId_1"));
+    assertTrue(actual.params().keySet().contains("engineId"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
@@ -105,29 +105,6 @@ class TestRunsFilters {
   }
 
   @Test
-  void filterRawNonTerminalStatesAndEngineId() {
-
-    // Unsorted NON_TERMINAL_STATES is the more likely use case.
-    RunsFilters filters = new RunsFilters(null, CbasRunStatus.NON_TERMINAL_STATES, "engineId_1");
-    WhereClause actual = filters.buildWhereClause();
-    assertEquals(
-        "WHERE (run.status in (:status_0,:status_1,:status_2,:status_3,:status_4,:status_5)) AND (run.engine_id = :engineId)",
-        actual.toString());
-
-    // We can't assert any ordering on which status ends up in which 'status_0'...'status_5'
-    // placeholder,
-    // but we can make sure all the right keys and values are in the map in SOME order...
-    assertEquals(
-        CbasRunStatus.NON_TERMINAL_STATES.stream()
-            .map(CbasRunStatus::toString)
-            .collect(Collectors.toSet()),
-        new HashSet<>(actual.params().values()));
-    assertEquals(
-        Set.of("status_0", "status_1", "status_2", "status_3", "status_4", "status_5", "engine_id"),
-        actual.params().keySet());
-  }
-
-  @Test
   void filterRunSetIdAndSortedNonTerminalStatuses() {
     UUID uuid = UUID.randomUUID();
     RunsFilters filters = new RunsFilters(uuid, sortedNonTerminalStatuses);

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
@@ -34,6 +34,7 @@ import cromwell.client.model.RunLog;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +93,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
 
@@ -114,7 +115,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateLastPolledTimestamp(runId1)).thenReturn(1);
 
     // Run the results update:
@@ -136,7 +137,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateLastPolledTimestamp(runId1)).thenReturn(0);
 
     // Run the results update:
@@ -158,7 +159,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(0);
     // Run the results update:
@@ -183,7 +184,7 @@ class TestRunCompletionHandlerUnit {
     Object cromwellOutputs = object.fromJson(outputs, RunLog.class).getOutputs();
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
     // Run the results update:
@@ -212,7 +213,7 @@ class TestRunCompletionHandlerUnit {
     Object cromwellOutputs = object.fromJson(emptyOutputs, RunLog.class).getOutputs();
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
     // Run the results update:
@@ -242,7 +243,7 @@ class TestRunCompletionHandlerUnit {
     List<String> failures = createWorkflowErrorsList();
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(1);
     doThrow(new RuntimeException("Some WDS error"))
@@ -273,7 +274,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(SYSTEM_ERROR), any())).thenReturn(1);
 
     // Run the results update:
@@ -300,7 +301,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(1);
     List<String> errors = createWorkflowErrorsList();
@@ -329,7 +330,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(0);
     List<String> errors = createWorkflowErrorsList();
@@ -358,7 +359,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
+    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(SYSTEM_ERROR), any())).thenReturn(1);
     List<String> failures = Collections.emptyList();
 

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
@@ -34,7 +34,6 @@ import cromwell.client.model.RunLog;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,7 +92,7 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
+    when(runDao.getRuns(any())).thenReturn(List.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
 
@@ -115,7 +114,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateLastPolledTimestamp(runId1)).thenReturn(1);
 
     // Run the results update:
@@ -137,7 +135,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateLastPolledTimestamp(runId1)).thenReturn(0);
 
     // Run the results update:
@@ -159,7 +156,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(0);
     // Run the results update:
@@ -184,7 +180,6 @@ class TestRunCompletionHandlerUnit {
     Object cromwellOutputs = object.fromJson(outputs, RunLog.class).getOutputs();
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
     // Run the results update:
@@ -213,7 +208,6 @@ class TestRunCompletionHandlerUnit {
     Object cromwellOutputs = object.fromJson(emptyOutputs, RunLog.class).getOutputs();
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(CbasRunStatus.COMPLETE), isA(OffsetDateTime.class)))
         .thenReturn(1);
     // Run the results update:
@@ -243,7 +237,6 @@ class TestRunCompletionHandlerUnit {
     List<String> failures = createWorkflowErrorsList();
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(1);
     doThrow(new RuntimeException("Some WDS error"))
@@ -274,7 +267,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(SYSTEM_ERROR), any())).thenReturn(1);
 
     // Run the results update:
@@ -301,7 +293,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(1);
     List<String> errors = createWorkflowErrorsList();
@@ -330,7 +321,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString()))
         .thenReturn(0);
     List<String> errors = createWorkflowErrorsList();
@@ -359,7 +349,6 @@ class TestRunCompletionHandlerUnit {
     Run run1Incomplete = createTestRun(runId1, null, RUNNING);
 
     // Set up mocks:
-    when(runDao.getRunByIdIfExists(any())).thenReturn(Optional.of(run1Incomplete));
     when(runDao.updateRunStatus(eq(runId1), eq(SYSTEM_ERROR), any())).thenReturn(1);
     List<String> failures = Collections.emptyList();
 


### PR DESCRIPTION
1. Added implementation of getting Run record by the runId (WorkflowId) and updated controller code to use it.
2. TestRunDao renamed to TestRunsFilters according to the test logic.
3. TestRunDao validates a new method with a call to db. Both TestRunDao and TestRunSetDao are manual tests requiring an explicit db cleanup after. Something to re-think later for a validation strategy.