### PR TITLE
WM-2304: Fix bugs in Cromwell Runner selector

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation "io.prometheus:simpleclient_httpserver:0.12.0"
     implementation "io.opencensus:opencensus-exporter-stats-prometheus:0.28.3"
     implementation "org.broadinstitute.cromwell:cromwell-client_2.13:0.1-28c780bfa-SNAP"
-    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.13:1.3.6-22ee00b"
+    implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.13:1.3.6-336b224-SNAP" // TODO: Remove when https://github.com/DataBiosphere/leonardo/pull/3831 is merged
     implementation 'bio.terra:terra-common-lib'
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'

--- a/service/src/main/java/bio/terra/cbas/dependencies/leonardo/LeonardoService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/leonardo/LeonardoService.java
@@ -40,10 +40,11 @@ public class LeonardoService implements HealthCheck {
     return new ServiceInfoApi(leonardoClient.getUnauthorizedApiClient());
   }
 
-  public List<ListAppResponse> getApps() throws LeonardoServiceException {
+  public List<ListAppResponse> getApps(boolean creatorOnly) throws LeonardoServiceException {
+    String creatorRoleSpecifier = creatorOnly ? "creator" : null;
     return executionWithRetryTemplate(
         listenerResetRetryTemplate,
-        () -> getAppsApi().listAppsV2(wdsServerConfiguration.instanceId(), null, null, null));
+        () -> getAppsApi().listAppsV2(wdsServerConfiguration.instanceId(), null, null, null, creatorRoleSpecifier));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/cbas/dependencies/wds/WdsClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wds/WdsClient.java
@@ -32,7 +32,9 @@ public class WdsClient {
     if (baseUriFromConfig.isPresent()) {
       uri = baseUriFromConfig.get();
     } else {
-      uri = dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL);
+      uri =
+          dependencyUrlLoader.loadDependencyUrl(
+              DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken);
     }
 
     ApiClient apiClient = new ApiClient().setBasePath(uri);

--- a/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/wes/CromwellClient.java
@@ -35,7 +35,8 @@ public class CromwellClient {
       uri = cromwellServerConfiguration.baseUri();
     } else {
       uri =
-          dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.CROMWELL_URL);
+          dependencyUrlLoader.loadDependencyUrl(
+              DependencyUrlLoader.DependencyUrlType.CROMWELL_URL, accessToken);
     }
     ApiClient apiClient = new ApiClient().setBasePath(uri);
     apiClient.setAccessToken(accessToken);

--- a/service/src/test/java/bio/terra/cbas/dependencies/common/TestDependencyUrlLoader.java
+++ b/service/src/test/java/bio/terra/cbas/dependencies/common/TestDependencyUrlLoader.java
@@ -6,6 +6,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.cbas.common.exceptions.DependencyNotAvailableException;
@@ -30,15 +33,17 @@ class TestDependencyUrlLoader {
 
   @Test
   void fetchesUrlsAppropriately() throws Exception {
+    String accessToken = "some-access-token";
 
     // Doesn't actually matter what this is, we can force the app utils mock to create whatever
-    // url we want. This is really just a token for testing that the wiring is happening properly
+    // url we want. This is really just a placeholder for testing that the wiring is happening
+    // properly
     // between the mocks.
     List<ListAppResponse> dummyListAppResponse = List.of(new ListAppResponse());
     String discoveredWdsUrl = "https://wds.com/prefix/wds";
     String discoveredCromwellUrl = "https://cromwell.com/prefix/cromwell";
 
-    when(leonardoService.getApps()).thenReturn(dummyListAppResponse);
+    when(leonardoService.getApps(any())).thenReturn(dummyListAppResponse);
     when(appUtils.findUrlForWds(dummyListAppResponse)).thenReturn(discoveredWdsUrl);
     when(appUtils.findUrlForCromwell(dummyListAppResponse)).thenReturn(discoveredCromwellUrl);
     var leonardoServerConfiguration =
@@ -49,23 +54,27 @@ class TestDependencyUrlLoader {
 
     assertEquals(
         discoveredWdsUrl,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
     assertEquals(
         discoveredCromwellUrl,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.CROMWELL_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.CROMWELL_URL, accessToken));
   }
 
   @Test
   void cachesDependencyUrls() throws Exception {
+    String accessToken = "some-access-token";
 
     // Doesn't actually matter what this is, we can force the app utils mock to create whatever
-    // url we want. This is really just a token for testing that the wiring is happening properly
+    // url we want. This is really just a placeholder for testing that the wiring is happening
+    // properly
     // between the mocks.
     List<ListAppResponse> dummyListAppResponse = List.of(new ListAppResponse());
     String discoveredWdsUrl = "https://wds.com/prefix/wds";
 
-    when(leonardoService.getApps()).thenReturn(dummyListAppResponse);
+    when(leonardoService.getApps(any())).thenReturn(dummyListAppResponse);
     when(appUtils.findUrlForWds(dummyListAppResponse)).thenReturn(discoveredWdsUrl);
     var leonardoServerConfiguration =
         new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
@@ -75,26 +84,73 @@ class TestDependencyUrlLoader {
 
     assertEquals(
         discoveredWdsUrl,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
-    // Even if the app utils would return something new, the dependency loader returns the cached
-    // value:
-    //    when(appUtils.findUrlForWds(dummyListAppResponse)).thenReturn("https://some-other-url");
+    // Load the same URL again:
     assertEquals(
         discoveredWdsUrl,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
+
+    // Assert that the backing call to Leonardo was only made once:
+    verify(leonardoService, times(1)).getApps(any());
+  }
+
+  @Test
+  void doesntCacheBetweenTokens() throws Exception {
+    String accessToken1 = "some-access-token";
+    String accessToken2 = "some-other-access-token";
+
+    // Doesn't actually matter what this is, we can force the app utils mock to create whatever
+    // url we want. This is really just a placeholder for testing that the wiring is happening
+    // properly
+    // between the mocks.
+    List<ListAppResponse> dummyListAppResponse = List.of(new ListAppResponse().appName("wds1"));
+    List<ListAppResponse> dummyListAppResponse2 = List.of(new ListAppResponse().appName("wds2"));
+    String discoveredWdsUrl1 = "https://wds.com/prefix/wds1";
+    String discoveredWdsUrl2 = "https://wds.com/prefix/wds2";
+
+    when(leonardoService.getApps(any()))
+        .thenReturn(dummyListAppResponse)
+        .thenReturn(dummyListAppResponse2);
+    when(appUtils.findUrlForWds(dummyListAppResponse)).thenReturn(discoveredWdsUrl1);
+    when(appUtils.findUrlForWds(dummyListAppResponse2)).thenReturn(discoveredWdsUrl2);
+
+    var leonardoServerConfiguration =
+        new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
+
+    DependencyUrlLoader dependencyUrlLoader =
+        new DependencyUrlLoader(leonardoService, appUtils, leonardoServerConfiguration);
+
+    assertEquals(
+        discoveredWdsUrl1,
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken1));
+
+    // Load the same dependency type again, but with a different token:
+    assertEquals(
+        discoveredWdsUrl2,
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken2));
+
+    // Assert that the backing call to Leonardo was only made twice:
+    verify(leonardoService, times(2)).getApps(any());
   }
 
   @Test
   void dependencyUrlCacheExpires() throws Exception {
+    String accessToken = "some-access-token";
+
     // Doesn't actually matter what this is, we can force the app utils mock to create whatever
-    // url we want. This is really just a token for testing that the wiring is happening properly
+    // url we want. This is really just a placeholder for testing that the wiring is happening
+    // properly
     // between the mocks.
     List<ListAppResponse> dummyListAppResponse = List.of(new ListAppResponse());
     String discoveredWdsUrl1 = "https://wds.com/prefix/wds";
     String discoveredWdsUrl2 = "https://new-wds.com/prefix/wds";
 
-    when(leonardoService.getApps()).thenReturn(dummyListAppResponse);
+    when(leonardoService.getApps(any())).thenReturn(dummyListAppResponse);
     when(appUtils.findUrlForWds(dummyListAppResponse)).thenReturn(discoveredWdsUrl1);
 
     var leonardoServerConfiguration =
@@ -105,7 +161,8 @@ class TestDependencyUrlLoader {
 
     assertEquals(
         discoveredWdsUrl1,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
     // Even if the app utils would return something new, the dependency loader returns the cached
     // value:
@@ -113,7 +170,8 @@ class TestDependencyUrlLoader {
 
     assertEquals(
         discoveredWdsUrl1,
-        dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL));
+        dependencyUrlLoader.loadDependencyUrl(
+            DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
     // But eventually, the cache expires and we DO get the new value:
     await()
@@ -121,13 +179,14 @@ class TestDependencyUrlLoader {
         .until(
             () ->
                 dependencyUrlLoader.loadDependencyUrl(
-                    DependencyUrlLoader.DependencyUrlType.WDS_URL),
+                    DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken),
             equalTo(discoveredWdsUrl2));
   }
 
   @Test
   void wrapsExceptionsFromLeonardo() throws Exception {
-    when(leonardoService.getApps())
+    String accessToken = "some-access-token";
+    when(leonardoService.getApps(any()))
         .thenThrow(new LeonardoServiceApiException(new ApiException(400, "Bad Leonardo!")));
     var leonardoServerConfiguration =
         new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
@@ -140,7 +199,7 @@ class TestDependencyUrlLoader {
             DependencyNotAvailableException.class,
             () ->
                 dependencyUrlLoader.loadDependencyUrl(
-                    DependencyUrlLoader.DependencyUrlType.WDS_URL));
+                    DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
     assertEquals(
         "Dependency not available: WDS. Failed to poll Leonardo for URL", thrown.getMessage());
@@ -151,14 +210,17 @@ class TestDependencyUrlLoader {
 
   @Test
   void forwardsExceptionsFromAppUtils() throws Exception {
+    String accessToken = "some-access-token";
+
     // Doesn't actually matter what this is, we can force the app utils mock to create whatever
-    // url we want. This is really just a token for testing that the wiring is happening properly
+    // url we want. This is really just a placeholder for testing that the wiring is happening
+    // properly
     // between the mocks.
     List<ListAppResponse> dummyListAppResponse = List.of(new ListAppResponse());
     DependencyNotAvailableException dnae =
         new DependencyNotAvailableException("WDS", "App util lookup failed");
 
-    when(leonardoService.getApps()).thenReturn(dummyListAppResponse);
+    when(leonardoService.getApps(any())).thenReturn(dummyListAppResponse);
     when(appUtils.findUrlForWds(dummyListAppResponse)).thenThrow(dnae);
     var leonardoServerConfiguration =
         new LeonardoServerConfiguration("", List.of(), List.of(), Duration.ofMinutes(10), false);
@@ -171,7 +233,7 @@ class TestDependencyUrlLoader {
             DependencyNotAvailableException.class,
             () ->
                 dependencyUrlLoader.loadDependencyUrl(
-                    DependencyUrlLoader.DependencyUrlType.WDS_URL));
+                    DependencyUrlLoader.DependencyUrlType.WDS_URL, accessToken));
 
     assertEquals(dnae, thrown);
   }

--- a/service/src/test/java/bio/terra/cbas/dependencies/leonardo/TestLeonardoService.java
+++ b/service/src/test/java/bio/terra/cbas/dependencies/leonardo/TestLeonardoService.java
@@ -62,7 +62,7 @@ class TestLeonardoService {
 
     doReturn(appsApi).when(leonardoService).getAppsApi();
 
-    assertEquals(expectedResponse, leonardoService.getApps());
+    assertEquals(expectedResponse, leonardoService.getApps(false));
   }
 
   @Test
@@ -82,7 +82,11 @@ class TestLeonardoService {
 
     doReturn(appsApi).when(leonardoService).getAppsApi();
 
-    assertThrows(SocketTimeoutException.class, leonardoService::getApps);
+    assertThrows(
+        SocketTimeoutException.class,
+        () -> {
+          leonardoService.getApps(false);
+        });
   }
 
   @Test
@@ -103,7 +107,11 @@ class TestLeonardoService {
     doReturn(appsApi).when(leonardoService).getAppsApi();
 
     LeonardoServiceApiException thrown =
-        assertThrows(LeonardoServiceApiException.class, leonardoService::getApps);
+        assertThrows(
+            LeonardoServiceApiException.class,
+            () -> {
+              leonardoService.getApps(false);
+            });
     assertEquals(expectedException, thrown.getCause());
   }
 }

--- a/service/src/test/java/bio/terra/cbas/dependencies/wds/TestWdsClient.java
+++ b/service/src/test/java/bio/terra/cbas/dependencies/wds/TestWdsClient.java
@@ -1,6 +1,8 @@
 package bio.terra.cbas.dependencies.wds;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.cbas.config.WdsServerConfiguration;
@@ -31,7 +33,8 @@ class TestWdsClient {
   void lookupWdsUrlWhenNecessary() throws Exception {
     WdsServerConfiguration wdsServerConfiguration =
         new WdsServerConfiguration(null, "instanceId", "apiV", false);
-    when(dependencyUrlLoader.loadDependencyUrl(DependencyUrlLoader.DependencyUrlType.WDS_URL))
+    when(dependencyUrlLoader.loadDependencyUrl(
+            eq(DependencyUrlLoader.DependencyUrlType.WDS_URL), any()))
         .thenReturn("https://my-wds-service:10101/wds");
 
     RecordsApi recordsApi =


### PR DESCRIPTION
Fixes:
- Makes the cache operate on both token and app type, so we don't cache the CROMWELL_RUNNER once and never again
- Makes the lookup specify the creator role so that we only ever get our own instances

Note: Need to wait for https://github.com/DataBiosphere/leonardo/pull/3831 and update the client version to be a non-snap