### PR TITLE
[WM-2267] Add show_all_users to GET run_sets

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -130,6 +130,14 @@ paths:
             type: integer
           description:
             How many items to return at once
+        - in: query
+          name: show_all_users
+          required: false
+          schema:
+            type: boolean
+            default: true
+          description:
+            Show run sets submitted by all users. If false, show only run sets submitted by current user. Defaults to true.
       responses:
         '200':
           $ref: '#/components/responses/GetRunSetListResponse'

--- a/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunSetsApiController.java
@@ -142,7 +142,8 @@ public class RunSetsApiController implements RunSetsApi {
   }
 
   @Override
-  public ResponseEntity<RunSetListResponse> getRunSets(UUID methodId, Integer pageSize) {
+  public ResponseEntity<RunSetListResponse> getRunSets(
+      UUID methodId, Integer pageSize, Boolean showAllUsers) {
     if (!samService.hasReadPermission()) {
       throw new ForbiddenException(SamService.READ_ACTION, SamService.RESOURCE_TYPE_WORKSPACE);
     }
@@ -155,6 +156,14 @@ public class RunSetsApiController implements RunSetsApi {
       filteredRunSet = Collections.singletonList(runSetDao.getRunSetWithMethodId(methodId));
     } else {
       filteredRunSet = runSetDao.getRunSets(pageSize, false);
+    }
+
+    if (Boolean.FALSE.equals(showAllUsers)) {
+      UserStatusInfo user = samService.getSamUser();
+      filteredRunSet =
+          filteredRunSet.stream()
+              .filter(runSet -> runSet.userId().equals(user.getUserSubjectId()))
+              .toList();
     }
 
     TimeLimitedUpdater.UpdateResult<RunSet> runSetUpdateResult =

--- a/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
+++ b/service/src/main/java/bio/terra/cbas/dependencies/sam/SamService.java
@@ -1,7 +1,6 @@
 package bio.terra.cbas.dependencies.sam;
 
 import bio.terra.cbas.dependencies.common.HealthCheck;
-import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.SamRetry;
 import bio.terra.common.sam.exception.SamExceptionFactory;
@@ -55,7 +54,7 @@ public class SamService implements HealthCheck {
     https://github.com/DataBiosphere/terra-common-lib/blob/eaaf6217ec0f024afa45aac14d21c8964c0f27c5/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java#L129-L132
     for details on how this is included in cloud logs, and logback.xml for console logs
     */
-    MDC.put("user", getSamUser().getUserSubjectId());
+    MDC.put("user", userInfo.getUserSubjectId());
 
     logger.debug(
         "Checking Sam permission for '{}' resource and '{}' action type for user on workspace '{}'.",
@@ -83,10 +82,6 @@ public class SamService implements HealthCheck {
 
   public ResourcesApi getResourcesApi() {
     return new ResourcesApi(samClient.getApiClient(bearerToken.getToken()));
-  }
-
-  public UserStatusInfo getSamUser() throws ErrorReportException {
-    return userInfo;
   }
 
   @Override

--- a/service/src/test/java/bio/terra/cbas/config/TestBeanConfig.java
+++ b/service/src/test/java/bio/terra/cbas/config/TestBeanConfig.java
@@ -1,21 +1,46 @@
 package bio.terra.cbas.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import bio.terra.cbas.dependencies.sam.SamClient;
 import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.sam.exception.SamForbiddenException;
+import java.util.Map;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.ApiResponse;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 class TestBeanConfig {
   private final BeanConfig beanConfig = new BeanConfig();
   private MockHttpServletRequest request;
+  @MockBean private ApiClient samApiClient;
+  final SamServerConfiguration samServerConfiguration =
+      new SamServerConfiguration("baseUri", false, "workspace-id", true);
+  @SpyBean private SamClient samClient;
 
   @BeforeEach
   void init() {
     request = new MockHttpServletRequest();
+    samApiClient = mock(ApiClient.class);
+    samClient = spy(new SamClient(samServerConfiguration));
+    doReturn(samApiClient).when(samClient).getApiClient(any());
   }
 
   @Test
@@ -28,5 +53,36 @@ class TestBeanConfig {
   @Test
   void noBearerToken() {
     assertThrows(UnauthorizedException.class, () -> beanConfig.bearerToken(request));
+  }
+
+  @Test
+  void testGetSamUserValidToken() throws ApiException {
+    doReturn(new ApiResponse<>(400, Map.of(), new UserStatusInfo().userSubjectId("foo-bar")))
+        .when(samApiClient)
+        .execute(any(), any());
+    UserStatusInfo user = beanConfig.userInfo(samClient, new BearerToken("token-baz"));
+    assertEquals("foo-bar", user.getUserSubjectId());
+    assertNull(user.getEnabled());
+    assertNull(user.getUserEmail());
+  }
+
+  @Test
+  void testGetSamUserAuthDisabled() {
+    when(samClient.checkAuthAccessWithSam()).thenReturn(false);
+    UserStatusInfo user = beanConfig.userInfo(samClient, null);
+    assertNull(user.getUserSubjectId());
+    assertNull(user.getEnabled());
+    assertNull(user.getUserEmail());
+  }
+
+  @Test
+  void testGetSamUserUnauthorized() throws ApiException {
+    doThrow(new ApiException(403, "Forbidden")).when(samApiClient).execute(any(), any());
+    BearerToken token = new BearerToken("token-baz");
+
+    SamForbiddenException e =
+        assertThrows(SamForbiddenException.class, () -> beanConfig.userInfo(samClient, token));
+    assertEquals("Error getting user status info from Sam: Forbidden", e.getMessage());
+    assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
   }
 }

--- a/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
@@ -69,6 +69,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class VerifyPactsAllControllers {
   private static final String API = "/api/batch/v1/run_sets";
 
+  @MockBean private UserStatusInfo userInfo;
   @MockBean private SamService samService;
   @MockBean private CromwellService cromwellService;
   @MockBean private DockstoreService dockstoreService;
@@ -184,9 +185,7 @@ class VerifyPactsAllControllers {
 
     when(cromwellService.submitWorkflowBatch(any(), any(), any()))
         .thenReturn(List.of(new WorkflowIdAndStatus().id(fixedCromwellRunUUID)));
-    when(samService.getSamUser())
-        .thenReturn(
-            new UserStatusInfo().userEmail("foo-email").userSubjectId("bar-id").enabled(true));
+    userInfo = new UserStatusInfo().userEmail("foo-email").userSubjectId("bar-id").enabled(true);
 
     // These values are returned so that they can be injected into variables in the Pact(s)
     HashMap<String, String> providerStateValues = new HashMap<>();


### PR DESCRIPTION
Prerequisite for manual shutdown. Allows optional specification of `show_all_users=false` (default is `true`) to filter run set output to only show runsets that the user making the request submitted.

Also adds UserStatusInfo `userInfo` bean instantiated once per request just like bearerToken, to avoid unnecessary repeat calls to Sam.