### PR TITLE
WM-2356: Set table role correctly

### DIFF
--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -88,4 +88,4 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changesets/20231102_set_table_role.yaml
-        relativeToChangelogFile: true
+      relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -89,3 +89,7 @@ databaseChangeLog:
   - include:
       file: changesets/20231102_set_table_role.yaml
       relativeToChangelogFile: true
+# Reminder! (Leave this at the end)
+# If you add a new table, don't forget to update the 20231102_set_table_role changeset to
+# include it. Don't worry, it's 'run on change' so updating it will trigger a re-run, not a
+# big error.

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -86,3 +86,6 @@ databaseChangeLog:
   - include:
       file: changesets/20230918_remove_method_prepopulation.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20231102_set_table_role.yaml
+        relativeToChangelogFile: true

--- a/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
+++ b/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  property:
+    # This property can be set via JAVA_OPTS if desired (eg -DsharedCromwellDbRole=...).
+    name: "dbRole"
+    value: ""
+  - changeSet:
+        id: "set table role"
+        author: chrisl
+        runAlways: true
+        runOnChange: true
+        preConditions:
+          - onFail: MARK_RAN
+          - sqlCheck:
+              expectedResult: 1
+              sql: SELECT count(1) FROM pg_roles WHERE '${dbRole}' != '' AND pg_roles.rolname = '${dbRole}'
+        sql: >
+            ALTER TABLE databasechangelog OWNER TO ${dbRole};
+            ALTER TABLE databasechangeloglock OWNER TO ${dbRole};
+            ALTER TABLE method OWNER TO ${dbRole};
+            ALTER TABLE method_version OWNER TO ${dbRole};
+            ALTER TABLE run OWNER TO ${dbRole};
+            ALTER TABLE run_set OWNER TO ${dbRole};

--- a/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
+++ b/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
@@ -1,22 +1,22 @@
 databaseChangeLog:
-  property:
-    # This property can be set via JAVA_OPTS if desired (eg -DsharedCromwellDbRole=...).
-    name: "dbRole"
-    value: ""
+  - property:
+      # This property can be set via JAVA_OPTS if desired (eg -DsharedCromwellDbRole=...).
+      name: "dbRole"
+      value: ""
   - changeSet:
-        id: "set table role"
-        author: chrisl
-        runAlways: true
-        runOnChange: true
-        preConditions:
-          - onFail: MARK_RAN
-          - sqlCheck:
-              expectedResult: 1
-              sql: SELECT count(1) FROM pg_roles WHERE '${dbRole}' != '' AND pg_roles.rolname = '${dbRole}'
-        sql: >
-            ALTER TABLE databasechangelog OWNER TO ${dbRole};
-            ALTER TABLE databasechangeloglock OWNER TO ${dbRole};
-            ALTER TABLE method OWNER TO ${dbRole};
-            ALTER TABLE method_version OWNER TO ${dbRole};
-            ALTER TABLE run OWNER TO ${dbRole};
-            ALTER TABLE run_set OWNER TO ${dbRole};
+      id: "set table role"
+      author: chrisl
+      runAlways: true
+      runOnChange: true
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 1
+            sql: SELECT count(1) FROM pg_roles WHERE '${dbRole}' != '' AND pg_roles.rolname = '${dbRole}'
+      sql: >
+          ALTER TABLE databasechangelog OWNER TO ${dbRole};
+          ALTER TABLE databasechangeloglock OWNER TO ${dbRole};
+          ALTER TABLE method OWNER TO ${dbRole};
+          ALTER TABLE method_version OWNER TO ${dbRole};
+          ALTER TABLE run OWNER TO ${dbRole};
+          ALTER TABLE run_set OWNER TO ${dbRole};

--- a/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
+++ b/service/src/main/resources/changelog/changesets/20231102_set_table_role.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - property:
-      # This property can be set via JAVA_OPTS if desired (eg -DsharedCromwellDbRole=...).
+      # This property can be set via JAVA_OPTS if desired (eg -DdbRole=...).
       name: "dbRole"
       value: ""
   - changeSet:


### PR DESCRIPTION
Tested in a live app with the resulting database ownership being correctly updated:
```
cbas_zy641f=> \dt
                  List of relations
 Schema |         Name          | Type  |    Owner
--------+-----------------------+-------+-------------
 public | databasechangelog     | table | cbas_zy641f
 public | databasechangeloglock | table | cbas_zy641f
 public | method                | table | cbas_zy641f
 public | method_version        | table | cbas_zy641f
 public | run                   | table | cbas_zy641f
 public | run_set               | table | cbas_zy641f
(6 rows)
```