### PR TITLE
[WM-1865] Surface Cromwell-level error in response

### DIFF
--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -153,10 +153,11 @@ public class SmartRunsPoller {
       }
     } catch (Exception e) {
       String errorMessage =
-          "Error fetching Cromwell-level error from Cromwell for run %s."
-              .formatted(updatableRun.runId());
+          "Error fetching Cromwell-level error from Cromwell for workflow %s."
+              .formatted(updatableRun.engineId());
       logger.error(errorMessage, e);
       errors.add(errorMessage);
+      errors.add("Error from Cromwell: %s".formatted(e.getMessage()));
     }
     return errors;
   }

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -152,8 +152,7 @@ public class SmartRunsPoller {
         errors.add(message);
       }
     } catch (Exception e) {
-      String errorMessage =
-          "Error fetching Cromwell-level error.";
+      String errorMessage = "Error fetching Cromwell-level error.";
       logger.error(errorMessage, e);
       errors.add("%s Details: %s".formatted(errorMessage, e.getMessage()));
     }

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -153,11 +153,9 @@ public class SmartRunsPoller {
       }
     } catch (Exception e) {
       String errorMessage =
-          "Error fetching Cromwell-level error from Cromwell for workflow %s."
-              .formatted(updatableRun.engineId());
+          "Error fetching Cromwell-level error.";
       logger.error(errorMessage, e);
-      errors.add(errorMessage);
-      errors.add("Error from Cromwell: %s".formatted(e.getMessage()));
+      errors.add("%s Details: %s".formatted(errorMessage, e.getMessage()));
     }
     return errors;
   }

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
@@ -453,14 +453,9 @@ public class TestSmartRunsPollerFunctional {
         .updateResults(eq(runToUpdate3), eq(EXECUTOR_ERROR), any(), captor.capture(), any());
 
     assertEquals(
-        "Error fetching Cromwell-level error from Cromwell for workflow %s."
-            .formatted(runningRunEngineId3),
-        captor.getValue().get(0));
-
-    assertEquals(
-        "Error from Cromwell: %s"
+        "Error fetching Cromwell-level error. Details: %s"
             .formatted(new ApiException("Cromwell client exception").getMessage()),
-        captor.getValue().get(1));
+        captor.getValue().get(0));
 
     assertEquals(1, actual.updatedList().size());
   }

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
@@ -453,8 +453,14 @@ public class TestSmartRunsPollerFunctional {
         .updateResults(eq(runToUpdate3), eq(EXECUTOR_ERROR), any(), captor.capture(), any());
 
     assertEquals(
-        "Error fetching Cromwell-level error from Cromwell for run %s.".formatted(runningRunId3),
+        "Error fetching Cromwell-level error from Cromwell for workflow %s."
+            .formatted(runningRunEngineId3),
         captor.getValue().get(0));
+
+    assertEquals(
+        "Error from Cromwell: %s"
+            .formatted(new ApiException("Cromwell client exception").getMessage()),
+        captor.getValue().get(1));
 
     assertEquals(1, actual.updatedList().size());
   }


### PR DESCRIPTION
See thread [here](https://broadinstitute.slack.com/archives/GHYJZ2ZE0/p1701379476185339) for more info. Currently the only fix in place is to surface the internal error in addition to the generic message. If users are still seeing this in the new multi-user app layout, the Cromwell client/spec may need to be updated with the proper WorkflowMetadataResponse object structure