### PR TITLE
WM-2424: Publish cbas client to artifactory

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -48,6 +48,13 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
+      - name: Publish to Artifactory
+        run: ./gradlew --build-cache :client:artifactoryPublish
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_REPO_KEY: "libs-release-local"
+
       - name: Construct dockerhub and GCR image names
         id: image-name
         run: |

--- a/client/artifactory.gradle
+++ b/client/artifactory.gradle
@@ -1,1 +1,49 @@
-// TODO! Maybe get started by copy/pasting from data-catalog?
+// This and the test below makes sure the build will fail reasonably if you try
+// to publish without the environment variables defined.
+def artifactory_username = System.getenv("ARTIFACTORY_USERNAME")
+def artifactory_password = System.getenv("ARTIFACTORY_PASSWORD")
+def artifactory_repo_key = System.getenv("ARTIFACTORY_REPO_KEY")
+
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(artifactoryPublish) &&
+        (artifactory_username == null || artifactory_password == null)) {
+        throw new GradleException("Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish")
+    }
+}
+
+java {
+    // Builds sources into the published package as part of the 'assemble' task.
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        cbasClientLibrary(MavenPublication) {
+            artifactId = "cbas-client"
+            from components.java
+            versionMapping {
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
+        }
+    }
+}
+
+artifactory {
+    publish {
+        contextUrl = "https://broadinstitute.jfrog.io/broadinstitute/"
+        repository {
+            repoKey  = "${artifactory_repo_key}" // The Artifactory repository key to publish to
+            username = "${artifactory_username}" // The publisher user name
+            password = "${artifactory_password}" // The publisher password
+        }
+        defaults {
+            // This is how we tell the Artifactory Plugin which artifacts should be published to Artifactory.
+            // Reference to Gradle publications defined in the build script.
+            publications("cbasClientLibrary")
+            publishArtifacts = true
+            publishPom = true
+        }
+    }
+}


### PR DESCRIPTION
Took a first pass at wiring up publishing the cbas client to artfactory.  Tried to follow what data-catalog was doing as per the comment in the artifactory.gradle file.

If someone could please verify that the secrets being used in the github action are available in this repo:

* ARTIFACTORY_USERNAME
* ARTIFACTORY_PASSWORD