### PR TITLE
WM-2302: Enable actuator API and micrometer custom metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 bootrun.log
+applicationinsights.log
 
 ### STS ###
 .apt_generated

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation "com.google.guava:guava:31.0.1-jre"
     implementation "io.prometheus:simpleclient_httpserver:0.12.0"
     implementation "io.opencensus:opencensus-exporter-stats-prometheus:0.28.3"
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation "org.broadinstitute.cromwell:cromwell-client_2.13:0.1-9a63f9364-SNAP"
     implementation "org.broadinstitute.dsde.workbench:leonardo-client_2.13:1.3.6-66d9fcf"
     implementation 'bio.terra:terra-common-lib'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.databiosphere:workspacedataservice-client-okhttp-javax:0.2.98-SNAPSHOT'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/service/src/main/java/bio/terra/cbas/App.java
+++ b/service/src/main/java/bio/terra/cbas/App.java
@@ -28,8 +28,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
       "bio.terra.common.tracing",
       // Scan all service-specific packages beneath the current package
       "bio.terra.cbas",
-      // Metrics exporting components & configs
-      "bio.terra.common.prometheus"
     })
 @ConfigurationPropertiesScan("bio.terra.cbas")
 @EnableRetry

--- a/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
+++ b/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
@@ -1,0 +1,31 @@
+package bio.terra.cbas.common;
+
+import bio.terra.cbas.models.CbasRunStatus;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MicrometerMetrics {
+
+  private final MeterRegistry meterRegistry;
+
+  public MicrometerMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void logRunCompletion(String completionTrigger, CbasRunStatus resultsStatus) {
+    Counter counter =
+        Counter.builder("run_completion")
+            .tag("completion_trigger", completionTrigger)
+            .tag("status", resultsStatus.toString())
+            .register(meterRegistry);
+    // This null check only triggers when running tests, where it's hard to mock out the
+    // meterRegistry's internal .counter method without springboot 3's observability frameworks.
+    // See https://github.com/DataBiosphere/terra-workspace-data-service/pull/461 (starting at
+    // QuartzJobTest.scala for an example of what we might want to do when we upgrade)
+    if (counter != null) {
+      counter.increment();
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
+++ b/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
@@ -20,12 +20,6 @@ public class MicrometerMetrics {
             .tag("completion_trigger", completionTrigger)
             .tag("status", resultsStatus.toString())
             .register(meterRegistry);
-    // This null check only triggers when running tests, where it's hard to mock out the
-    // meterRegistry's internal .counter method without springboot 3's observability frameworks.
-    // See https://github.com/DataBiosphere/terra-workspace-data-service/pull/461 (starting at
-    // QuartzJobTest.scala for an example of what we might want to do when we upgrade)
-    if (counter != null) {
-      counter.increment();
-    }
+    counter.increment();
   }
 }

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -17,12 +17,12 @@ import bio.terra.cbas.monitoring.TimeLimitedUpdater.UpdateResult;
 import bio.terra.cbas.runsets.monitoring.SmartRunsPoller;
 import bio.terra.cbas.runsets.results.RunCompletionHandler;
 import bio.terra.cbas.runsets.results.RunCompletionResult;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -90,9 +90,11 @@ public class RunsApiController implements RunsApi {
     CbasRunStatus resultsStatus = CbasRunStatus.fromCromwellStatus(body.getState().toString());
     List<String> failures = body.getFailures();
 
-    Counter counter = Counter.builder("run_completion")
-        .tag("completion_trigger", "callback")
-        .tag("status", resultsStatus.toString()).register(meterRegistry);
+    Counter counter =
+        Counter.builder("run_completion")
+            .tag("completion_trigger", "callback")
+            .tag("status", resultsStatus.toString())
+            .register(meterRegistry);
     counter.increment();
 
     log.info(

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -5,6 +5,7 @@ import static bio.terra.cbas.common.MetricsUtil.recordMethodCompletion;
 import static bio.terra.cbas.common.MetricsUtil.recordOutboundApiRequestCompletion;
 
 import bio.terra.cbas.common.MetricsUtil;
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.config.CbasApiConfiguration;
 import bio.terra.cbas.dependencies.wds.WdsClientUtils;
 import bio.terra.cbas.dependencies.wes.CromwellService;
@@ -31,16 +32,19 @@ public class SmartRunsPoller {
   private final CromwellService cromwellService;
   private final RunCompletionHandler runCompletionHandler;
   private final CbasApiConfiguration cbasApiConfiguration;
+  private final MicrometerMetrics micrometerMetrics;
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SmartRunsPoller.class);
 
   public SmartRunsPoller(
       CromwellService cromwellService,
       RunCompletionHandler runCompletionHandler,
-      CbasApiConfiguration cbasApiConfiguration) {
+      CbasApiConfiguration cbasApiConfiguration,
+      MicrometerMetrics micrometerMetrics) {
     this.cromwellService = cromwellService;
     this.runCompletionHandler = runCompletionHandler;
     this.cbasApiConfiguration = cbasApiConfiguration;
+    this.micrometerMetrics = micrometerMetrics;
   }
 
   /**
@@ -193,6 +197,7 @@ public class SmartRunsPoller {
         }
       }
       // Call Run Completion handler to update results
+      micrometerMetrics.logRunCompletion("smartpoller", updatedRunState);
       var updateResult =
           runCompletionHandler.updateResults(
               updatableRun, updatedRunState, outputs, errors, engineStatusChanged);

--- a/service/src/main/java/bio/terra/cbas/runsets/results/RunCompletionHandler.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/results/RunCompletionHandler.java
@@ -3,6 +3,7 @@ package bio.terra.cbas.runsets.results;
 import static bio.terra.cbas.common.MetricsUtil.recordMethodCompletion;
 
 import bio.terra.cbas.common.DateUtils;
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.common.exceptions.OutputProcessingException;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dependencies.wds.WdsService;
@@ -28,13 +29,19 @@ public class RunCompletionHandler {
   private final RunDao runDao;
   private final WdsService wdsService;
   private final ObjectMapper objectMapper;
+  private final MicrometerMetrics micrometerMetrics;
   private static final org.slf4j.Logger logger =
       LoggerFactory.getLogger(RunCompletionHandler.class);
 
-  public RunCompletionHandler(RunDao runDao, WdsService wdsService, ObjectMapper objectMapper) {
+  public RunCompletionHandler(
+      RunDao runDao,
+      WdsService wdsService,
+      ObjectMapper objectMapper,
+      MicrometerMetrics micrometerMetrics) {
     this.runDao = runDao;
     this.wdsService = wdsService;
     this.objectMapper = objectMapper;
+    this.micrometerMetrics = micrometerMetrics;
   }
 
   /*

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -55,6 +55,20 @@ cbas:
     # How often to check downstream services for health:
     healthCheckIntervalSeconds: 300
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: info,health,prometheus
+      base-path: /actuator
+      path-mapping:
+          info: version2
+          health: status2
+          prometheus: prometheus
+  endpoint:
+    health:
+      show-details: ALWAYS
+
 workflow-engines:
   cromwell:
     # This value comes from the config.

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -59,12 +59,11 @@ management:
   endpoints:
     web:
       exposure:
-        include: info,health,prometheus
+        include: info,health
       base-path: /actuator
       path-mapping:
-          info: version2
-          health: status2
-          prometheus: prometheus
+          info: info
+          health: health
   endpoint:
     health:
       show-details: ALWAYS

--- a/service/src/main/resources/applicationinsights.json
+++ b/service/src/main/resources/applicationinsights.json
@@ -1,0 +1,6 @@
+{
+  "customDimensions": {
+    "workspaceId": "${WORKSPACE_ID}",
+    "service.version": "${RELEASE_NAME}"
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.common.exceptions.ForbiddenException;
 import bio.terra.cbas.common.exceptions.MissingRunOutputsException;
 import bio.terra.cbas.common.exceptions.RunNotFoundException;
@@ -37,7 +38,6 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -77,7 +77,7 @@ class TestRunsApiController {
   @Autowired private ObjectMapper objectMapper;
   @MockBean private SamService samService;
 
-  @MockBean private MeterRegistry meterRegistry;
+  @MockBean private MicrometerMetrics micrometerMetrics;
 
   private static final UUID returnedRunId = UUID.randomUUID();
   private static final UUID returnedRunEngineId = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -37,6 +37,7 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.sam.exception.SamInterruptedException;
 import bio.terra.common.sam.exception.SamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -75,6 +76,8 @@ class TestRunsApiController {
   // tests:
   @Autowired private ObjectMapper objectMapper;
   @MockBean private SamService samService;
+
+  @MockBean private MeterRegistry meterRegistry;
 
   private static final UUID returnedRunId = UUID.randomUUID();
   private static final UUID returnedRunEngineId = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/VerifyPactsAllControllers.java
@@ -10,6 +10,7 @@ import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
 import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider;
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.config.CbasApiConfiguration;
 import bio.terra.cbas.dao.MethodDao;
 import bio.terra.cbas.dao.MethodVersionDao;
@@ -91,6 +92,7 @@ class VerifyPactsAllControllers {
   @MockBean private RunSetAbortManager abortManager;
   @MockBean private RunCompletionHandler runCompletionHandler;
   @Autowired private ObjectMapper objectMapper;
+  @MockBean private MicrometerMetrics micrometerMetrics;
 
   // This mockMVC is what we use to test API requests and responses:
   @Autowired private MockMvc mockMvc;

--- a/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cbas.common.DateUtils;
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.models.Method;
 import java.util.List;
 import java.util.UUID;
@@ -14,11 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TestMethodDao {
 
+  @MockBean MicrometerMetrics micrometerMetrics;
   @Autowired MethodDao methodDao;
   UUID methodId1 = UUID.randomUUID();
   UUID methodId2 = UUID.randomUUID();

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.config.CbasApiConfiguration;
 import bio.terra.cbas.dependencies.wes.CromwellService;
 import bio.terra.cbas.models.CbasRunSetStatus;
@@ -83,6 +84,7 @@ public class TestSmartRunsPollerFunctional {
   private SmartRunsPoller smartRunsPoller;
   private RunCompletionHandler runCompletionHandler;
   private CbasApiConfiguration cbasApiConfiguration;
+  private MicrometerMetrics micrometerMetrics;
 
   static String outputDefinition =
       """
@@ -180,8 +182,10 @@ public class TestSmartRunsPollerFunctional {
     runCompletionHandler = mock(RunCompletionHandler.class);
     cbasApiConfiguration = mock(CbasApiConfiguration.class);
     when(cbasApiConfiguration.getMaxSmartPollRunUpdateSeconds()).thenReturn(1);
+    micrometerMetrics = mock(MicrometerMetrics.class);
     smartRunsPoller =
-        new SmartRunsPoller(cromwellService, runCompletionHandler, cbasApiConfiguration);
+        new SmartRunsPoller(
+            cromwellService, runCompletionHandler, cbasApiConfiguration, micrometerMetrics);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.cbas.common.DateUtils;
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dependencies.wds.WdsService;
 import bio.terra.cbas.dependencies.wds.WdsServiceApiException;
@@ -45,6 +46,8 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = RunCompletionHandler.class)
 class TestRunCompletionHandlerFunctional {
+
+  private MicrometerMetrics micrometerMetrics = mock(MicrometerMetrics.class);
 
   public ObjectMapper objectMapper =
       new ObjectMapper()
@@ -99,7 +102,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededNoOutputsComplete() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     UUID runId1 = UUID.randomUUID();
     RunSet runSet1 = createRunSet(UUID.randomUUID(), "[]");
@@ -123,7 +126,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionWorkflowErrorsRecordedDateTime() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     var errorList = List.of("error1", "error 2");
     UUID runId1 = UUID.randomUUID();
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
@@ -145,7 +148,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionNoStatusChangeNoOutputsUpdateDateTimeNoRecord() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     UUID runId1 = UUID.randomUUID();
     Run run1Incomplete = createTestRun(runId1, null, SYSTEM_ERROR);
@@ -166,7 +169,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededNoOutputsNoErrorsToUpdate() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     UUID runId1 = UUID.randomUUID();
     RunSet runSet1 = createRunSet(UUID.randomUUID(), "[]");
     Run run1Incomplete = createTestRun(runId1, runSet1, RUNNING);
@@ -189,7 +192,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededNoStatusUpdate() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     UUID runId1 = UUID.randomUUID();
     RunSet runSet1 = createRunSet(UUID.randomUUID(), outputDefinition);
     Run run1Incomplete = createTestRun(runId1, runSet1, CANCELED);
@@ -212,7 +215,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionFailedNoRecordsUpdated() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     UUID runId1 = UUID.randomUUID();
     RunSet runSet1 = createRunSet(UUID.randomUUID(), "[]");
     Run run1Incomplete = createTestRun(runId1, runSet1, RUNNING);
@@ -235,7 +238,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededWithOutputsSaved() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     // Set up run to expect non-empty outputs
     RunSet runSet1 = createRunSet(UUID.randomUUID(), outputDefinition);
     UUID runId1 = UUID.randomUUID();
@@ -261,7 +264,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededWithEmptyOutputs() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     // Set up run to expect non-empty outputs
     RunSet runSet = createRunSet(UUID.randomUUID(), "[]");
     UUID runId1 = UUID.randomUUID();
@@ -289,7 +292,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededWhenWdsThrowsSavedStatusWithErrors() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     // Set up run to expect non-empty outputs
     RunSet runSet = createRunSet(UUID.randomUUID(), outputDefinition);
     UUID runId1 = UUID.randomUUID();
@@ -321,7 +324,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionReturnsValidationWithOutputsErrorProcessing() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     // Set up run to expect non-empty outputs
     RunSet runSet = createRunSet(UUID.randomUUID(), outputDefinition);
     UUID runId1 = UUID.randomUUID();
@@ -351,7 +354,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSucceededWithEmptyOutputsNoFailures() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     // Using Gson here since Cromwell client uses it to interpret runLogValue into Java objects.
     Gson object = new Gson();
@@ -377,7 +380,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSuccessSavingFailures() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     // Using Gson here since Cromwell client uses it to interpret runLogValue into Java objects.
     Gson object = new Gson();
@@ -405,7 +408,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionFailedErrorsPulledNoRecordUpdated() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     // Using Gson here since Cromwell client uses it to interpret runLogValue into Java objects.
     Gson object = new Gson();
@@ -433,7 +436,7 @@ class TestRunCompletionHandlerFunctional {
   @Test
   void updateRunCompletionSuccessWithEmptyFailures() {
     RunCompletionHandler runCompletionHandler =
-        new RunCompletionHandler(runDao, wdsService, objectMapper);
+        new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
 
     // Using Gson here since Cromwell client uses it to interpret runLogValue into Java objects.
     Gson object = new Gson();

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import bio.terra.cbas.common.MicrometerMetrics;
 import bio.terra.cbas.common.exceptions.OutputProcessingException;
 import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dependencies.wds.WdsService;
@@ -161,7 +162,9 @@ class TestRunCompletionHandlerUnit {
   public void init() {
     RunDao runsDao = mock(RunDao.class);
     WdsService wdsService = mock(WdsService.class);
-    runCompletionHandler = new RunCompletionHandler(runsDao, wdsService, objectMapper);
+    MicrometerMetrics micrometerMetrics = mock(MicrometerMetrics.class);
+    runCompletionHandler =
+        new RunCompletionHandler(runsDao, wdsService, objectMapper, micrometerMetrics);
   }
 
   @Test


### PR DESCRIPTION
### Description
Note: depends on extra env variables being added in https://github.com/broadinstitute/terra-helmfile/pull/4980 for the custom dimensions.

### Examples
Sample actuator API metrics (MRG logs):

<img width="1433" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/db359bea-03eb-4eb8-ba15-495be76aaee7">

Sample custom application metrics (application insights logs:
(note: counting a total of 6 workflow completions, all via the callback API)
<img width="1132" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/28039ae8-8f7a-4008-a09c-82a570caa85d">

