### PR TITLE
TSPS-147 add jersey-hk2 dependency to cbas client generation

### DIFF
--- a/client/swagger.gradle
+++ b/client/swagger.gradle
@@ -7,6 +7,9 @@ dependencies {
 
     implementation 'io.swagger.core.v3:swagger-annotations'
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
+
+    // Expose to consumer applications compile
+    api group: 'org.glassfish.jersey.inject', name: 'jersey-hk2'
 }
 
 def artifactGroup = "${group}.cbas"


### PR DESCRIPTION
It seems there is a[ breaking change introduced](https://stackoverflow.com/a/46405129) in jersey version 2.26  that caused this library to not be needed in new versions but still needed in previous versions.  When I tried using this client w/o this this change i ran into this issue

```
java.lang.IllegalStateException: InjectionManagerFactory not found.
        at org.glassfish.jersey.internal.inject.Injections.lambda$lookupInjectionManagerFactory$0(Injections.java:74)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at org.glassfish.jersey.internal.inject.Injections.lookupInjectionManagerFactory(Injections.java:74)
        at org.glassfish.jersey.internal.inject.Injections.createInjectionManager(Injections.java:44)
        at org.glassfish.jersey.client.ClientConfig$State.initRuntime(ClientConfig.java:413)
        at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(Values.java:317)
        at org.glassfish.jersey.client.ClientConfig.getRuntime(ClientConfig.java:820)
        at org.glassfish.jersey.client.ClientRequest.getClientRuntime(ClientRequest.java:176)
        at org.glassfish.jersey.client.ClientRequest.getInjectionManager(ClientRequest.java:567)
        at org.glassfish.jersey.client.JerseyWebTarget.onBuilder(JerseyWebTarget.java:371)
        at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:199)
        at org.glassfish.jersey.client.JerseyWebTarget.request(JerseyWebTarget.java:38)
        at bio.terra.cbas.client.ApiClient.invokeAPI(ApiClient.java:674)
        at bio.terra.cbas.api.PublicApi.getStatus(PublicApi.java:68)
```

which led me down to path to realized we needed this library compiled to get it working.  I added it on our repos code first and the client worked and then looked at other places to see if this was an issue and it is! There are a couple [places in our org](https://github.com/search?q=org%3ADataBiosphere%20jersey-hk2&type=code) where client consumers pull in the dependency themselves with a comment like "we do this because the client doesnt" (this seems to be an issue with the tdr client mostly) so this fix is just adding the library client side so consumers dont have to.  I tested this locally and it removed the need for me to bring in the library consumer side.  Because it isnt used in jersey versions post 2.26 this change wouldnt affect them either other than having an unused dependency in the client jar.