### PR TITLE
WM-2487: Treat failure to update WDS as retryable

### DIFF
--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -133,6 +133,7 @@ public class RunsApiController implements RunsApi {
     RunCompletionResult result =
         runCompletionHandler.updateResults(
             runRecord.get(), resultsStatus, body.getOutputs(), failures);
+
     micrometerMetrics.logRunCompletion("callback", resultsStatus);
     return new ResponseEntity<>(result.toHttpStatus());
   }

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
@@ -292,7 +292,7 @@ class TestRunCompletionHandlerFunctional {
   }
 
   @Test
-  void updateRunCompletionSucceededWhenWdsThrowsSavedStatusWithErrors() throws WdsServiceException {
+  void dontPermanentlyFailWhenWdsApiFlakes() throws WdsServiceException {
     RunCompletionHandler runCompletionHandler =
         new RunCompletionHandler(runDao, wdsService, objectMapper, micrometerMetrics);
     // Set up run to expect non-empty outputs
@@ -317,10 +317,9 @@ class TestRunCompletionHandlerFunctional {
 
     // Validate the results:
     verify(runDao, times(0)).updateRunStatus(eq(runId1), any(), any());
-    verify(runDao, times(1))
-        .updateRunStatusWithError(eq(runId1), eq(SYSTEM_ERROR), any(), anyString());
+    verify(runDao, times(0)).updateRunStatusWithError(any(), any(), any(), anyString());
 
-    assertEquals(RunCompletionResult.SUCCESS, result);
+    assertEquals(RunCompletionResult.ERROR, result);
   }
 
   @Test


### PR DESCRIPTION
Tested by:
- Created a "sabotaged" branch which threw API exceptions 60% of the time
- Submitted a set of workflows
- Watched logs for evidence of the error being thrown in CBAS

<img width="1340" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/d6704008-fea4-4622-81fa-c3df046b92d1">
<img width="1214" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/a6bb9169-ac4f-4191-9aa8-e2e86bd47446">

- Watched logs for evidence of Cromwell retrying the callback
<img width="960" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/7958bc96-a7dd-4050-a06e-f47bfa07fd42">

- Observed that all workflows eventually succeeded and data tables were updated
- Observed that the completion trigger was indeed still callback
<img width="1153" alt="image" src="https://github.com/DataBiosphere/cbas/assets/13006282/316284aa-2a0c-47bc-be2c-ed65a9832b77">

(Note: there was actually both a smartpoller and callback entry, indicating that the callback happened _as well as_ a successful update on smartpolling. That's a good thing - it means the fallback mechanism of letting the smartpoller pick up if the callback gives up is _also_ working well)