### PR TITLE
[QA-2240] Combine tag and publish into one job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,7 +171,7 @@ jobs:
           event-name: ${{ github.event_name }}
 
   tag-and-publish:
-    if: success() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: success() && needs.bump-check.outputs.is-bump == 'no' 
     uses: ./.github/workflows/tag-and-publish.yml
     needs: [ build, unit-tests-and-sonarqube, integration-tests, bump-check ]
     secrets: inherit

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,7 +171,7 @@ jobs:
           event-name: ${{ github.event_name }}
 
   tag-and-publish:
-    if: success() && needs.bump-check.outputs.is-bump == 'no' 
+    if: success() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/tag-and-publish.yml
     needs: [ build, unit-tests-and-sonarqube, integration-tests, bump-check ]
     secrets: inherit

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -45,7 +45,8 @@ jobs:
         uses: ./.github/workflows/tag.yml
         with:
           release-branches: main
-        secrets: inherit
+        secrets:
+          BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -21,16 +21,7 @@ env:
   GOOGLE_PROJECT: broad-dsp-gcr-public
 
 jobs:
-  tag-job:
-    if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
-    uses: ./.github/workflows/tag.yml
-    with:
-      release-branches: main
-    secrets: inherit
-
-  publish-job:
-    needs: [ tag-job ]
-    if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
+  tag-and-publish-job:
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -49,6 +40,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+      - id: dispatch-tag
+        name: Dispatch tag
+        uses: ./.github/workflows/tag.yml
+        with:
+          release-branches: main
+        secrets: inherit
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -56,7 +53,11 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
+      - name: Print tag
+        run: |
+          echo ${{ steps.dispatch-tag.outputs.new-tag }}
       - name: Publish to Artifactory
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: ./gradlew --build-cache :client:artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -64,38 +65,46 @@ jobs:
           ARTIFACTORY_REPO_KEY: "libs-release-local"
 
       - name: Construct dockerhub and GCR image names
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         id: image-name
         run: |
-          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ needs.tag-job.outputs.new-tag }}
-          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ needs.tag-job.outputs.new-tag }}
+          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new-tag }}
+          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new-tag }}
 
       - name: Build image locally with jib
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
           --image=${{ steps.image-name.outputs.DOCKERHUB_NAME }} \
           -Djib.console=plain
 
       - name: Run Trivy vulnerability scanner
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           image: ${{ steps.image-name.outputs.DOCKERHUB_NAME }}
 
       - name: Login to Docker Hub
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: docker/login-action@v1
         with:
           username: dsdejenkins
           password: ${{ secrets.DSDEJENKINS_DOCKERHUB_PASSWORD }}
 
       - name: Push dockerhub image
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker push ${{ steps.image-name.outputs.DOCKERHUB_NAME }}
 
       - name: Re-tag image for GCR
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker tag ${{ steps.image-name.outputs.DOCKERHUB_NAME }} ${{ steps.image-name.outputs.GCR_NAME }}
 
       - name: Set up gcloud
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Authenticate to Google Cloud
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: 'google-github-actions/auth@v0'
         with:
           # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
@@ -103,12 +112,15 @@ jobs:
           service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
 
       - name: Explicitly auth Docker for GCR
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: gcloud auth configure-docker --quiet
 
       - name: Push GCR image
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker push ${{ steps.image-name.outputs.GCR_NAME }}
 
       - name: Clone Cromwhelm
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: actions/checkout@v2
         with:
           repository: broadinstitute/cromwhelm
@@ -116,6 +128,7 @@ jobs:
           path: cromwhelm
 
       - name: Update CBAS Helm Chart in cromwhelm
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         env:
           BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
@@ -124,7 +137,7 @@ jobs:
           git checkout main
           ls -la
           HELM_CUR_TAG=$(grep "/cbas:" terra-batch-libchart/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ needs.tag-job.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           # prefixing search and replacement text with 'cbas' is needed to avoid replacing tag for cbas-ui
           # when both cbas and cbas-ui have the same image version
@@ -137,6 +150,7 @@ jobs:
           cd -
 
       - name: Clone terra-helmfile
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/terra-helmfile
@@ -144,22 +158,24 @@ jobs:
           path: terra-helmfile
 
       - name: Update workflows-app in terra-helmfile
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: |
           set -e
           cd terra-helmfile
           HELM_CUR_TAG=$(grep "/cbas:" charts/workflows-app/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ needs.tag-job.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" charts/workflows-app/values.yaml
           cd -
 
       - name: Make PR in terra-helmfile
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         env:
           BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
           set -e
-          HELM_NEW_TAG=${{ needs.tag-job.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
           JIRA_ID=${{ steps.ensure-jira-id.outputs.JIRA_ID }}
           if [[ $JIRA_ID == "missing" ]]; then
             echo "JIRA_ID missing, PR to terra-helmfile will not be created"

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Print tag
         run: |
-          echo ${{ steps.dispatch-tag.outputs.new-tag }}
+          echo ${{ steps.dispatch-tag.outputs.new_tag }}
       - name: Publish to Artifactory
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: ./gradlew --build-cache :client:artifactoryPublish
@@ -72,8 +72,8 @@ jobs:
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         id: image-name
         run: |
-          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new-tag }}
-          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new-tag }}
+          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new_tag }}
+          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new_tag }}
 
       - name: Build image locally with jib
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
@@ -141,7 +141,7 @@ jobs:
           git checkout main
           ls -la
           HELM_CUR_TAG=$(grep "/cbas:" terra-batch-libchart/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           # prefixing search and replacement text with 'cbas' is needed to avoid replacing tag for cbas-ui
           # when both cbas and cbas-ui have the same image version
@@ -167,7 +167,7 @@ jobs:
           set -e
           cd terra-helmfile
           HELM_CUR_TAG=$(grep "/cbas:" charts/workflows-app/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" charts/workflows-app/values.yaml
           cd -
@@ -179,7 +179,7 @@ jobs:
           GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
           set -e
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new-tag }}
+          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
           JIRA_ID=${{ steps.ensure-jira-id.outputs.JIRA_ID }}
           if [[ $JIRA_ID == "missing" ]]; then
             echo "JIRA_ID missing, PR to terra-helmfile will not be created"

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -60,16 +60,12 @@ jobs:
       - name: Print tag
         run: |
           echo ${{ steps.dispatch-tag.outputs.new_tag }}
-      - name: Build code
-        run: |
-          ./gradlew --build-cache assemble
       - name: Publish to Artifactory
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: ./gradlew --build-cache :client:artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-release-local"
+          ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
 
       - name: Construct dockerhub and GCR image names
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -34,19 +34,18 @@ jobs:
         id: ensure-jira-id
         run: |
           JIRA_ID=$(echo "$COMMIT_MESSAGE" | grep -Eo '[A-Z][A-Z]+-[0-9]+' | xargs echo -n | tr '[:space:]' ',')
-          [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; }
+          [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
           echo ::set-output name=JIRA_ID::${JIRA_ID}
       - name: Checkout current code
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
-      - id: dispatch-tag
+      - id: tag
         name: Dispatch tag
         uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           DEFAULT_BUMP: patch
-          DRY_RUN: true
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
@@ -56,65 +55,46 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-
-      - name: Simulate new version line step
-        run: |
-          version_line=$(cat settings.gradle | grep -e "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'")
-          new_line=$(echo "$version_line" | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${{ steps.dispatch-tag.outputs.new_tag }}\3/")
-          echo "old line"
-          cat settings.gradle
-          echo "new_line"
-          echo $new_line
-          sed -E -i.bak -e "s/${version_line}/${new_line}/" settings.gradle
-          cat settings.gradle
       - name: Publish to Artifactory
         run: ./gradlew --build-cache :client:artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+          ARTIFACTORY_REPO_KEY: "libs-release-local"
 
       - name: Construct dockerhub and GCR image names
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         id: image-name
         run: |
-          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new_tag }}
-          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.dispatch-tag.outputs.new_tag }}
+          echo ::set-output name=DOCKERHUB_NAME::${DOCKERHUB_ORG}/${SERVICE_NAME}:${{ steps.tag.outputs.new_tag }}
+          echo ::set-output name=GCR_NAME::us.gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.new_tag }}
 
       - name: Build image locally with jib
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
           --image=${{ steps.image-name.outputs.DOCKERHUB_NAME }} \
           -Djib.console=plain
 
       - name: Run Trivy vulnerability scanner
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
           image: ${{ steps.image-name.outputs.DOCKERHUB_NAME }}
 
       - name: Login to Docker Hub
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: docker/login-action@v1
         with:
           username: dsdejenkins
           password: ${{ secrets.DSDEJENKINS_DOCKERHUB_PASSWORD }}
 
       - name: Push dockerhub image
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker push ${{ steps.image-name.outputs.DOCKERHUB_NAME }}
 
       - name: Re-tag image for GCR
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker tag ${{ steps.image-name.outputs.DOCKERHUB_NAME }} ${{ steps.image-name.outputs.GCR_NAME }}
 
       - name: Set up gcloud
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Authenticate to Google Cloud
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: 'google-github-actions/auth@v0'
         with:
           # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
@@ -122,15 +102,12 @@ jobs:
           service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
 
       - name: Explicitly auth Docker for GCR
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: gcloud auth configure-docker --quiet
 
       - name: Push GCR image
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: docker push ${{ steps.image-name.outputs.GCR_NAME }}
 
       - name: Clone Cromwhelm
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: actions/checkout@v2
         with:
           repository: broadinstitute/cromwhelm
@@ -138,7 +115,6 @@ jobs:
           path: cromwhelm
 
       - name: Update CBAS Helm Chart in cromwhelm
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         env:
           BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
@@ -147,7 +123,7 @@ jobs:
           git checkout main
           ls -la
           HELM_CUR_TAG=$(grep "/cbas:" terra-batch-libchart/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
+          HELM_NEW_TAG=${{ steps.tag.outputs.new_tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           # prefixing search and replacement text with 'cbas' is needed to avoid replacing tag for cbas-ui
           # when both cbas and cbas-ui have the same image version
@@ -160,7 +136,6 @@ jobs:
           cd -
 
       - name: Clone terra-helmfile
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/terra-helmfile
@@ -168,24 +143,22 @@ jobs:
           path: terra-helmfile
 
       - name: Update workflows-app in terra-helmfile
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: |
           set -e
           cd terra-helmfile
           HELM_CUR_TAG=$(grep "/cbas:" charts/workflows-app/values.yaml | sed "s,.*/cbas:,,")
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
+          HELM_NEW_TAG=${{ steps.tag.outputs.new_tag }}
           [[ -n "$HELM_CUR_TAG" && -n "$HELM_NEW_TAG" ]]
           sed -i "s/$HELM_CUR_TAG/$HELM_NEW_TAG/" charts/workflows-app/values.yaml
           cd -
 
       - name: Make PR in terra-helmfile
-        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         env:
           BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
           GH_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
         run: |
           set -e
-          HELM_NEW_TAG=${{ steps.dispatch-tag.outputs.new_tag }}
+          HELM_NEW_TAG=${{ steps.tag.outputs.new_tag }}
           JIRA_ID=${{ steps.ensure-jira-id.outputs.JIRA_ID }}
           if [[ $JIRA_ID == "missing" ]]; then
             echo "JIRA_ID missing, PR to terra-helmfile will not be created"

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -61,6 +61,8 @@ jobs:
         run: |
           version_line=$(cat settings.gradle | grep -e "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'")
           new_line=$(echo "$version_line" | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${{ steps.dispatch-tag.outputs.new_tag }}\3/")
+          echo "old line"
+          cat settings.gradle
           echo "new_line"
           echo $new_line
           sed -E -i.bak -e "s/${version_line}/${new_line}/" settings.gradle

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Print tag
         run: |
           echo ${{ steps.dispatch-tag.outputs.new_tag }}
+      - name: Build code
+        run: |
+          ./gradlew --build-cache assembly
       - name: Publish to Artifactory
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: ./gradlew --build-cache :client:artifactoryPublish

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -57,9 +57,14 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Print tag
+      - name: Simulate new version line step
         run: |
-          echo ${{ steps.dispatch-tag.outputs.new_tag }}
+          version_line=$(cat settings.gradle | grep -e "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'")
+          new_line=$(echo "$version_line" | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${{ steps.dispatch-tag.outputs.new_tag }}\3/")
+          echo "new_line"
+          echo $new_line
+          sed -E -i.bak -e "s/${version_line}/${new_line}/" settings.gradle
+          cat settings.gradle
       - name: Publish to Artifactory
         run: ./gradlew --build-cache :client:artifactoryPublish
         env:

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -42,11 +42,14 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - id: dispatch-tag
         name: Dispatch tag
-        uses: ./.github/workflows/tag.yml
-        with:
-          release-branches: main
-        secrets:
-          BROADBOT_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          DEFAULT_BUMP: patch
+          DRY_RUN: true
+          RELEASE_BRANCHES: main
+          VERSION_FILE_PATH: settings.gradle
+          VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -34,7 +34,7 @@ jobs:
         id: ensure-jira-id
         run: |
           JIRA_ID=$(echo "$COMMIT_MESSAGE" | grep -Eo '[A-Z][A-Z]+-[0-9]+' | xargs echo -n | tr '[:space:]' ',')
-          [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
+          [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; }
           echo ::set-output name=JIRA_ID::${JIRA_ID}
       - name: Checkout current code
         uses: actions/checkout@v2

--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -62,7 +62,7 @@ jobs:
           echo ${{ steps.dispatch-tag.outputs.new_tag }}
       - name: Build code
         run: |
-          ./gradlew --build-cache assembly
+          ./gradlew --build-cache assemble
       - name: Publish to Artifactory
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         run: ./gradlew --build-cache :client:artifactoryPublish


### PR DESCRIPTION
Combine `tag-job` and `publish-job` into one job (`tag-and-publish-job`). This is because the `settings.gradle` need to be updated to the new release tag prior to publishing `cbas-client` to artifactory with the new version.