### PR TITLE
[QA-2244] Do not block tag-and-publish on merge

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,7 +171,7 @@ jobs:
           event-name: ${{ github.event_name }}
 
   tag-and-publish:
-    if: success() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: always() && needs.bump-check.outputs.is-bump == 'no' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/tag-and-publish.yml
     needs: [ build, unit-tests-and-sonarqube, integration-tests, bump-check ]
     secrets: inherit


### PR DESCRIPTION
The `tag-and-publish` job should run on `merge` even the integration test may be flaky at times. As long as integration tests pass during PRs we should be good.