### PR TITLE
[WM-2507] Upgrade Gradle to 7.5 and spring-web dependency to 3.2.3

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.11.RELEASE'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.15'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates Gradle version to `7.5` and spring-boot version to `3.2.3`. 

Gradle version was updated using the below command per the instructions at https://docs.gradle.org/8.4/release-notes.html#upgrade-instructions. I didn't change this by hand. Updating the spring-boot version was done by me. I was running into some Gradle cache and incompatibility issues when upgrading Gradle to 8.4 which didn't resolve even after attempting various things. 7.5 version worked and hence I upgraded to that instead.
```
./gradlew wrapper --gradle-version=7.5
```

Running `../gradlew dependencyInsight --dependency org.springframework:spring-web` before updating dependencies:
```
service % ../gradlew dependencyInsight --dependency org.springframework:spring-web

> Task :service:dependencyInsight
....

org.springframework:spring-web:5.3.27
+--- org.springframework:spring-webmvc:5.3.27
|    \--- org.springframework.boot:spring-boot-starter-web:2.6.15
|         +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
|         \--- io.opencensus:opencensus-contrib-spring:0.31.1 (requested org.springframework.boot:spring-boot-starter-web:2.1.5.RELEASE)
|              \--- bio.terra:terra-common-lib:0.0.78-SNAPSHOT:20230315.211744-2
|                   \--- compileClasspath
+--- org.springframework.boot:spring-boot-starter-json:2.6.15
|    \--- org.springframework.boot:spring-boot-starter-web:2.6.15 (*)
\--- org.springframework.boot:spring-boot-starter-web:2.6.15 (*)

org.springframework:spring-webmvc:5.3.27
\--- org.springframework.boot:spring-boot-starter-web:2.6.15
     +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
     \--- io.opencensus:opencensus-contrib-spring:0.31.1 (requested org.springframework.boot:spring-boot-starter-web:2.1.5.RELEASE)
          \--- bio.terra:terra-common-lib:0.0.78-SNAPSHOT:20230315.211744-2
               \--- compileClasspath
```

After updating dependencies does show `spring-web` upgraded to a non-vulnerable version [6.1.4](https://mvnrepository.com/artifact/org.springframework/spring-web/6.1.4):
```
service % ../gradlew dependencyInsight --dependency org.springframework:spring-web

> Task :service:dependencyInsight
...

org.springframework:spring-web:6.1.4
+--- org.springframework:spring-webmvc:6.1.4
|    \--- org.springframework.boot:spring-boot-starter-web:3.2.3
|         +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
|         \--- io.opencensus:opencensus-contrib-spring:0.31.1 (requested org.springframework.boot:spring-boot-starter-web:2.1.5.RELEASE)
|              \--- bio.terra:terra-common-lib:0.0.78-SNAPSHOT:20230315.211744-2
|                   \--- compileClasspath
+--- org.springframework.boot:spring-boot-starter-json:3.2.3
|    \--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)
\--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)

org.springframework:spring-webmvc:6.1.4
\--- org.springframework.boot:spring-boot-starter-web:3.2.3
     +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
     \--- io.opencensus:opencensus-contrib-spring:0.31.1 (requested org.springframework.boot:spring-boot-starter-web:2.1.5.RELEASE)
          \--- bio.terra:terra-common-lib:0.0.78-SNAPSHOT:20230315.211744-2
               \--- compileClasspath

```

Closes https://broadworkbench.atlassian.net/browse/WM-2507