### PR TITLE
[WM-2554] use ProviderStates enum from ECM

### DIFF
--- a/service/src/test/java/bio/terra/cbas/pact/EcmPactTest.java
+++ b/service/src/test/java/bio/terra/cbas/pact/EcmPactTest.java
@@ -15,7 +15,7 @@ import bio.terra.cbas.config.EcmServerConfiguration;
 import bio.terra.cbas.dependencies.ecm.EcmClient;
 import bio.terra.cbas.dependencies.ecm.EcmService;
 import bio.terra.common.iam.BearerToken;
-// import bio.terra.externalcreds.pact.ProviderStates;
+import bio.terra.externalcreds.pact.ProviderStates;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,8 +59,7 @@ public class EcmPactTest {
   @Pact(consumer = "cbas", provider = "ecm")
   RequestResponsePact getGithubAccessToken(PactDslWithProvider builder) {
     return builder
-        // .given(ProviderStates.USER_IS_REGISTERED)
-        .given("test_user@test.com is registered with ECM")
+        .given(ProviderStates.USER_IS_REGISTERED)
         .uponReceiving("a github token request")
         .path("/api/oauth/v1/github/access-token")
         .headers("Authorization", "Bearer accessToken")


### PR DESCRIPTION
we can make this minor improvement now that https://github.com/DataBiosphere/terra-external-credentials-manager/pull/189 is merged.