### PR TITLE
WM-2575: Add DB column for githash

### DIFF
--- a/service/src/main/java/bio/terra/cbas/controllers/MethodsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/MethodsApiController.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -310,7 +311,8 @@ public class MethodsApiController implements MethodsApi {
             null,
             postMethodRequest.getMethodUrl(),
             cbasContextConfig.getWorkspaceId(),
-            branchOrTagName);
+            branchOrTagName,
+            Optional.empty());
 
     String templateRunSetName =
         String.format("%s/%s workflow", method.name(), methodVersion.name());

--- a/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
@@ -40,14 +40,13 @@ public class MethodVersionDao {
             new BeanPropertySqlParameterSource(methodVersion));
 
     if (methodVersion.methodVersionDetails().isPresent()) {
-      inserted +=
-          jdbcTemplate.update(
-              "insert into github_method_version_details (%S, %S) "
-                      .formatted(
-                          GithubMethodVersionDetails.GITHASH_COL,
-                          GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
-                  + "values (:githash, :methodVersionId)",
-              new BeanPropertySqlParameterSource(methodVersion.methodVersionDetails().get()));
+      jdbcTemplate.update(
+          "insert into github_method_version_details (%S, %S) "
+                  .formatted(
+                      GithubMethodVersionDetails.GITHASH_COL,
+                      GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
+              + "values (:githash, :methodVersionId)",
+          new BeanPropertySqlParameterSource(methodVersion.methodVersionDetails().get()));
     }
 
     return inserted;

--- a/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
@@ -39,15 +39,17 @@ public class MethodVersionDao {
                 + "values (:methodVersionId, :methodId, :name, :description, :created, :lastRunSetId, :url, :originalWorkspaceId, :branchOrTagName)",
             new BeanPropertySqlParameterSource(methodVersion));
 
-    methodVersion.methodVersionDetails().ifPresent(methodVersionDetails ->
-        jdbcTemplate.update(
-            "insert into github_method_version_details (%S, %S) "
-                    .formatted(
-                        GithubMethodVersionDetails.GITHASH_COL,
-                        GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
-                + "values (:githash, :methodVersionId)",
-            new BeanPropertySqlParameterSource(methodVersionDetails))
-    );
+    methodVersion
+        .methodVersionDetails()
+        .ifPresent(
+            methodVersionDetails ->
+                jdbcTemplate.update(
+                    "insert into github_method_version_details (%S, %S) "
+                            .formatted(
+                                GithubMethodVersionDetails.GITHASH_COL,
+                                GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
+                        + "values (:githash, :methodVersionId)",
+                    new BeanPropertySqlParameterSource(methodVersionDetails)));
 
     return inserted;
   }

--- a/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
@@ -23,10 +23,10 @@ public class MethodVersionDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  public static final String methodVersionJoinMethod =
+  public static final String METHOD_VERSION_JOIN_METHOD =
       "INNER JOIN method on method_version.%S = method.%S "
           .formatted(MethodVersion.METHOD_ID_COL, Method.METHOD_ID_COL);
-  public static final String methodVersionJoinGithubMethodVersionDetails =
+  public static final String METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS =
       "LEFT JOIN github_method_version_details on method_version.%S = github_method_version_details.%S "
           .formatted(
               MethodVersion.METHOD_VERSION_ID_COL,
@@ -57,8 +57,8 @@ public class MethodVersionDao {
   public MethodVersion getMethodVersion(UUID methodVersionId) {
     String sql =
         "SELECT * FROM method_version "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS
             + "WHERE method_version.%S = :method_version_id"
                 .formatted(MethodVersion.METHOD_VERSION_ID_COL);
     return jdbcTemplate
@@ -72,8 +72,8 @@ public class MethodVersionDao {
   public List<MethodVersion> getMethodVersions() {
     String sql =
         "SELECT * FROM method_version "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails;
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS;
     return jdbcTemplate.query(
         sql, new MapSqlParameterSource(), new MethodVersionMappers.DeepMethodVersionMapper());
   }
@@ -81,8 +81,8 @@ public class MethodVersionDao {
   public List<MethodVersion> getMethodVersionsForMethod(Method method) {
     String sql =
         "SELECT * FROM method_version "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS
             + "WHERE method_version.%S = :methodId".formatted(MethodVersion.METHOD_ID_COL);
     return jdbcTemplate.query(
         sql,

--- a/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
@@ -23,10 +23,10 @@ public class MethodVersionDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  public static String methodVersionJoinMethod =
+  public static final String methodVersionJoinMethod =
       "INNER JOIN method on method_version.%S = method.%S "
           .formatted(MethodVersion.METHOD_ID_COL, Method.METHOD_ID_COL);
-  public static String methodVersionJoinGithubMethodVersionDetails =
+  public static final String methodVersionJoinGithubMethodVersionDetails =
       "LEFT JOIN github_method_version_details on method_version.%S = github_method_version_details.%S "
           .formatted(
               MethodVersion.METHOD_VERSION_ID_COL,

--- a/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/MethodVersionDao.java
@@ -39,15 +39,15 @@ public class MethodVersionDao {
                 + "values (:methodVersionId, :methodId, :name, :description, :created, :lastRunSetId, :url, :originalWorkspaceId, :branchOrTagName)",
             new BeanPropertySqlParameterSource(methodVersion));
 
-    if (methodVersion.methodVersionDetails().isPresent()) {
-      jdbcTemplate.update(
-          "insert into github_method_version_details (%S, %S) "
-                  .formatted(
-                      GithubMethodVersionDetails.GITHASH_COL,
-                      GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
-              + "values (:githash, :methodVersionId)",
-          new BeanPropertySqlParameterSource(methodVersion.methodVersionDetails().get()));
-    }
+    methodVersion.methodVersionDetails().ifPresent(methodVersionDetails ->
+        jdbcTemplate.update(
+            "insert into github_method_version_details (%S, %S) "
+                    .formatted(
+                        GithubMethodVersionDetails.GITHASH_COL,
+                        GithubMethodVersionDetails.METHOD_VERSION_ID_COL)
+                + "values (:githash, :methodVersionId)",
+            new BeanPropertySqlParameterSource(methodVersionDetails))
+    );
 
     return inserted;
   }

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -1,5 +1,8 @@
 package bio.terra.cbas.dao;
 
+import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinGithubMethodVersionDetails;
+import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinMethod;
+
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.mappers.RunSetMapper;
 import bio.terra.cbas.dao.util.SqlPlaceholderMapping;
@@ -27,10 +30,12 @@ public class RunDao {
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
   // SQL query for reading Run records.
+
   private static final String RUN_SELECT_SQL =
       "SELECT * FROM run INNER JOIN run_set ON run.run_set_id = run_set.run_set_id"
           + " INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-          + " INNER JOIN method ON method_version.method_id = method.method_id ";
+          + methodVersionJoinMethod
+          + methodVersionJoinGithubMethodVersionDetails;
 
   public RunDao(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;

--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -1,7 +1,7 @@
 package bio.terra.cbas.dao;
 
-import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinGithubMethodVersionDetails;
-import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinMethod;
+import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS;
+import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_METHOD;
 
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.mappers.RunSetMapper;
@@ -34,8 +34,8 @@ public class RunDao {
   private static final String RUN_SELECT_SQL =
       "SELECT * FROM run INNER JOIN run_set ON run.run_set_id = run_set.run_set_id"
           + " INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-          + methodVersionJoinMethod
-          + methodVersionJoinGithubMethodVersionDetails;
+          + METHOD_VERSION_JOIN_METHOD
+          + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS;
 
   public RunDao(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -29,8 +29,8 @@ public class RunSetDao {
   }
 
   public static final String RUN_SET_JOIN_METHOD_VERSION =
-      "INNER JOIN method_version ON run_set.%S = method_version.%S ".formatted(
-          RunSet.METHOD_VERSION_ID_COL, MethodVersion.METHOD_VERSION_ID_COL);
+      "INNER JOIN method_version ON run_set.%S = method_version.%S "
+          .formatted(RunSet.METHOD_VERSION_ID_COL, MethodVersion.METHOD_VERSION_ID_COL);
 
   public List<RunSet> getRunSets(Integer pageSize, boolean isTemplate) {
     String sql =

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -1,12 +1,13 @@
 package bio.terra.cbas.dao;
 
-import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinGithubMethodVersionDetails;
-import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinMethod;
+import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS;
+import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_METHOD;
 
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.mappers.RunSetMapper;
 import bio.terra.cbas.dao.util.SqlPlaceholderMapping;
 import bio.terra.cbas.models.CbasRunSetStatus;
+import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -27,12 +28,16 @@ public class RunSetDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
+  public static final String RUN_SET_JOIN_METHOD_VERSION =
+      "INNER JOIN method_version ON run_set.%S = method_version.%S ".formatted(
+          RunSet.METHOD_VERSION_ID_COL, MethodVersion.METHOD_VERSION_ID_COL);
+
   public List<RunSet> getRunSets(Integer pageSize, boolean isTemplate) {
     String sql =
         "SELECT * FROM run_set "
-            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails
+            + RUN_SET_JOIN_METHOD_VERSION
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS
             + "WHERE run_set.is_template = :isTemplate "
             + "ORDER BY run_set.submission_timestamp DESC";
 
@@ -49,9 +54,9 @@ public class RunSetDao {
   public RunSet getRunSet(UUID runSetId) {
     String sql =
         "SELECT * FROM run_set "
-            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails
+            + RUN_SET_JOIN_METHOD_VERSION
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS
             + "WHERE run_set.run_set_id = :runSetId ";
     return jdbcTemplate
         .query(sql, new MapSqlParameterSource("runSetId", runSetId), new RunSetMapper())
@@ -66,9 +71,9 @@ public class RunSetDao {
     // Returns run sets in order from most to least recent
     String sql =
         "SELECT * FROM run_set "
-            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-            + methodVersionJoinMethod
-            + methodVersionJoinGithubMethodVersionDetails
+            + RUN_SET_JOIN_METHOD_VERSION
+            + METHOD_VERSION_JOIN_METHOD
+            + METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS
             + "WHERE method.method_id = :methodId "
             + "ORDER BY run_set.submission_timestamp DESC";
     return jdbcTemplate.query(

--- a/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunSetDao.java
@@ -1,5 +1,8 @@
 package bio.terra.cbas.dao;
 
+import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinGithubMethodVersionDetails;
+import static bio.terra.cbas.dao.MethodVersionDao.methodVersionJoinMethod;
+
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.mappers.RunSetMapper;
 import bio.terra.cbas.dao.util.SqlPlaceholderMapping;
@@ -27,8 +30,11 @@ public class RunSetDao {
   public List<RunSet> getRunSets(Integer pageSize, boolean isTemplate) {
     String sql =
         "SELECT * FROM run_set "
-            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id AND run_set.is_template = :isTemplate "
-            + "INNER JOIN method on method_version.method_id = method.method_id GROUP BY run_set.run_set_id, method_version.method_version_id, method.method_id ORDER BY MIN(run_set.submission_timestamp) DESC";
+            + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
+            + methodVersionJoinMethod
+            + methodVersionJoinGithubMethodVersionDetails
+            + "WHERE run_set.is_template = :isTemplate "
+            + "ORDER BY run_set.submission_timestamp DESC";
 
     HashMap<String, Object> parameterMap = new HashMap<>(Map.of("isTemplate", isTemplate));
 
@@ -44,9 +50,9 @@ public class RunSetDao {
     String sql =
         "SELECT * FROM run_set "
             + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-            + "INNER JOIN method on method_version.method_id = method.method_id "
-            + "WHERE run_set.run_set_id = :runSetId GROUP BY run_set.run_set_id, method_version.method_version_id, method.method_id "
-            + "ORDER BY MIN(run_set.submission_timestamp) DESC";
+            + methodVersionJoinMethod
+            + methodVersionJoinGithubMethodVersionDetails
+            + "WHERE run_set.run_set_id = :runSetId ";
     return jdbcTemplate
         .query(sql, new MapSqlParameterSource("runSetId", runSetId), new RunSetMapper())
         .get(0);
@@ -61,9 +67,10 @@ public class RunSetDao {
     String sql =
         "SELECT * FROM run_set "
             + "INNER JOIN method_version ON run_set.method_version_id = method_version.method_version_id "
-            + "INNER JOIN method on method_version.method_id = method.method_id "
-            + "WHERE method.method_id = :methodId GROUP BY run_set.run_set_id, method_version.method_version_id, method.method_id "
-            + "ORDER BY MIN(run_set.submission_timestamp) DESC";
+            + methodVersionJoinMethod
+            + methodVersionJoinGithubMethodVersionDetails
+            + "WHERE method.method_id = :methodId "
+            + "ORDER BY run_set.submission_timestamp DESC";
     return jdbcTemplate.query(
         sql, new MapSqlParameterSource(Map.of("methodId", methodId)), new RunSetMapper());
   }

--- a/service/src/main/java/bio/terra/cbas/dao/mappers/GithubMethodVersionDetailsMapper.java
+++ b/service/src/main/java/bio/terra/cbas/dao/mappers/GithubMethodVersionDetailsMapper.java
@@ -1,0 +1,26 @@
+package bio.terra.cbas.dao.mappers;
+
+import bio.terra.cbas.models.GithubMethodVersionDetails;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.RowMapper;
+
+public class GithubMethodVersionDetailsMapper
+    implements RowMapper<Optional<GithubMethodVersionDetails>> {
+
+  @Override
+  public Optional<GithubMethodVersionDetails> mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    String githash = rs.getString(GithubMethodVersionDetails.GITHASH_COL);
+
+    if (githash == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(
+          new GithubMethodVersionDetails(
+              githash, rs.getObject(GithubMethodVersionDetails.METHOD_VERSION_ID_COL, UUID.class)));
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/cbas/dao/mappers/MethodVersionMappers.java
+++ b/service/src/main/java/bio/terra/cbas/dao/mappers/MethodVersionMappers.java
@@ -1,32 +1,43 @@
 package bio.terra.cbas.dao.mappers;
 
+import bio.terra.cbas.models.GithubMethodVersionDetails;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.MethodVersion;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.jdbc.core.RowMapper;
 
 public final class MethodVersionMappers {
 
   private MethodVersionMappers() {}
 
+  @NotNull
+  private static MethodVersion getMethodVersion(ResultSet rs, int rowNum, Method method)
+      throws SQLException {
+    Optional<GithubMethodVersionDetails> githubMethodVersionDetails =
+        new GithubMethodVersionDetailsMapper().mapRow(rs, rowNum);
+    return new MethodVersion(
+        rs.getObject(MethodVersion.METHOD_VERSION_ID_COL, UUID.class),
+        method,
+        rs.getString(MethodVersion.NAME_COL),
+        rs.getString(MethodVersion.DESCRIPTION__COL),
+        rs.getObject(MethodVersion.CREATED_COL, OffsetDateTime.class),
+        rs.getObject(MethodVersion.LAST_RUN_SET_ID_COL, UUID.class),
+        rs.getString(MethodVersion.URL_COL),
+        rs.getObject(MethodVersion.ORIGINAL_WORKSPACE_ID_COL, UUID.class),
+        rs.getString(MethodVersion.BRANCH_OR_TAG_NAME),
+        githubMethodVersionDetails);
+  }
+
   public static class DeepMethodVersionMapper implements RowMapper<MethodVersion> {
     @Override
     public MethodVersion mapRow(ResultSet rs, int rowNum) throws SQLException {
       Method method = new MethodMapper().mapRow(rs, rowNum);
-
-      return new MethodVersion(
-          rs.getObject(MethodVersion.METHOD_VERSION_ID_COL, UUID.class),
-          method,
-          rs.getString(MethodVersion.NAME_COL),
-          rs.getString(MethodVersion.DESCRIPTION__COL),
-          rs.getObject(MethodVersion.CREATED_COL, OffsetDateTime.class),
-          rs.getObject(MethodVersion.LAST_RUN_SET_ID_COL, UUID.class),
-          rs.getString(MethodVersion.URL_COL),
-          rs.getObject(MethodVersion.ORIGINAL_WORKSPACE_ID_COL, UUID.class),
-          rs.getString(MethodVersion.BRANCH_OR_TAG_NAME));
+      return getMethodVersion(rs, rowNum, method);
     }
   }
 
@@ -39,16 +50,7 @@ public final class MethodVersionMappers {
 
     @Override
     public MethodVersion mapRow(ResultSet rs, int rowNum) throws SQLException {
-      return new MethodVersion(
-          rs.getObject(MethodVersion.METHOD_VERSION_ID_COL, UUID.class),
-          method,
-          rs.getString(MethodVersion.NAME_COL),
-          rs.getString(MethodVersion.DESCRIPTION__COL),
-          rs.getObject(MethodVersion.CREATED_COL, OffsetDateTime.class),
-          rs.getObject(MethodVersion.LAST_RUN_SET_ID_COL, UUID.class),
-          rs.getString(MethodVersion.URL_COL),
-          rs.getObject(MethodVersion.ORIGINAL_WORKSPACE_ID_COL, UUID.class),
-          rs.getString(MethodVersion.BRANCH_OR_TAG_NAME));
+      return getMethodVersion(rs, rowNum, method);
     }
   }
 }

--- a/service/src/main/java/bio/terra/cbas/models/GithubMethodVersionDetails.java
+++ b/service/src/main/java/bio/terra/cbas/models/GithubMethodVersionDetails.java
@@ -1,0 +1,8 @@
+package bio.terra.cbas.models;
+
+import java.util.UUID;
+
+public record GithubMethodVersionDetails(String githash, UUID methodVersionId) {
+  public static final String GITHASH_COL = "githash";
+  public static final String METHOD_VERSION_ID_COL = "method_version_id";
+}

--- a/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
+++ b/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
@@ -35,10 +35,6 @@ public record MethodVersion(
     return originalWorkspaceId;
   }
 
-  public Optional<GithubMethodVersionDetails> getMethodVersionDetails() {
-    return methodVersionDetails;
-  }
-
   public MethodVersion withMethodVersionId(UUID methodVersionId) {
     return new MethodVersion(
         methodVersionId,

--- a/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
+++ b/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
@@ -38,4 +38,32 @@ public record MethodVersion(
   public Optional<GithubMethodVersionDetails> getMethodVersionDetails() {
     return methodVersionDetails;
   }
+
+  public MethodVersion withMethodVersionId(UUID methodVersionId) {
+    return new MethodVersion(
+        methodVersionId,
+        method,
+        name,
+        description,
+        created,
+        lastRunSetId,
+        url,
+        originalWorkspaceId,
+        branchOrTagName,
+        methodVersionDetails);
+  }
+
+  public MethodVersion withMethodVersionDetails(GithubMethodVersionDetails methodVersionDetails) {
+    return new MethodVersion(
+        methodVersionId,
+        method,
+        name,
+        description,
+        created,
+        lastRunSetId,
+        url,
+        originalWorkspaceId,
+        branchOrTagName,
+        Optional.of(methodVersionDetails));
+  }
 }

--- a/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
+++ b/service/src/main/java/bio/terra/cbas/models/MethodVersion.java
@@ -1,6 +1,7 @@
 package bio.terra.cbas.models;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 public record MethodVersion(
@@ -12,10 +13,12 @@ public record MethodVersion(
     UUID lastRunSetId,
     String url,
     UUID originalWorkspaceId,
-    String branchOrTagName) {
+    String branchOrTagName,
+    Optional<GithubMethodVersionDetails> methodVersionDetails) {
 
   // Corresponding table column names in database
   public static final String METHOD_VERSION_ID_COL = "method_version_id";
+  public static final String METHOD_ID_COL = "method_id";
   public static final String NAME_COL = "method_version_name";
   public static final String DESCRIPTION__COL = "method_version_description";
   public static final String CREATED_COL = "method_version_created";
@@ -30,5 +33,9 @@ public record MethodVersion(
 
   public UUID getOriginalWorkspaceId() {
     return originalWorkspaceId;
+  }
+
+  public Optional<GithubMethodVersionDetails> getMethodVersionDetails() {
+    return methodVersionDetails;
   }
 }

--- a/service/src/main/java/bio/terra/cbas/models/RunSet.java
+++ b/service/src/main/java/bio/terra/cbas/models/RunSet.java
@@ -24,6 +24,7 @@ public record RunSet(
 
   // Corresponding table column names in database
   public static final String RUN_SET_ID_COL = "run_set_id";
+  public static final String METHOD_VERSION_ID_COL = "method_version_id";
   public static final String STATUS_COL = "status";
   public static final String NAME_COL = "run_set_name";
   public static final String DESCRIPTION_COL = "run_set_description";

--- a/service/src/main/resources/changelog/changelog.yaml
+++ b/service/src/main/resources/changelog/changelog.yaml
@@ -96,6 +96,9 @@ databaseChangeLog:
       file: changesets/20240223_backfill_github_method_details.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/20240416_github_method_version_details.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/20231102_set_table_role.yaml
       relativeToChangelogFile: true
 # Reminder! (Leave 20231102_set_table_role.yaml at the end)

--- a/service/src/main/resources/changelog/changesets/20240416_github_method_version_details.yaml
+++ b/service/src/main/resources/changelog/changesets/20240416_github_method_version_details.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: "1"
+      author: cjllanwarne
+      changes:
+        - createTable:
+            tableName: github_method_version_details
+            columns:
+              - column:
+                  name: githash
+                  type: varchar(40)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: method_version_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    foreignKeyName: fk_method_version_details_method_version_id
+                    references: method_version(method_version_id)

--- a/service/src/main/resources/changelog/changesets/20240416_github_method_version_details.yaml
+++ b/service/src/main/resources/changelog/changesets/20240416_github_method_version_details.yaml
@@ -10,7 +10,7 @@ databaseChangeLog:
                   name: githash
                   type: varchar(40)
                   constraints:
-                    nullable: true
+                    nullable: false
               - column:
                   name: method_version_id
                   type: uuid

--- a/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestMethodsApiController.java
@@ -39,6 +39,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -896,7 +897,8 @@ class TestMethodsApiController {
           null,
           "file://method1/v1.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   private static final MethodVersion method1Version2 =
       new MethodVersion(
@@ -908,7 +910,8 @@ class TestMethodsApiController {
           null,
           "file://method1/v2.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   private static final UUID method2RunSet1Id = UUID.randomUUID();
   private static final UUID method2RunSet2Id = UUID.randomUUID();
@@ -948,7 +951,8 @@ class TestMethodsApiController {
           method2RunSet1Id,
           "file://method2/v1.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   private static final UUID method2Version2VersionID = UUID.randomUUID();
   private static final MethodVersion method2Version2 =
@@ -961,7 +965,8 @@ class TestMethodsApiController {
           method2RunSet2Id,
           "file://method2/v2.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   private static final RunSet method2Version1Runset =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunSetsApiController.java
@@ -81,6 +81,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -301,7 +302,8 @@ class TestRunSetsApiController {
                 null,
                 workflowUrl,
                 workspaceId,
-                "test_branch"));
+                "test_branch",
+                Optional.empty()));
 
     when(methodVersionDao.getMethodVersion(dockstoreMethodVersionId))
         .thenReturn(
@@ -321,7 +323,8 @@ class TestRunSetsApiController {
                 null,
                 dockstoreWorkflowUrl,
                 workspaceId,
-                "develop"));
+                "develop",
+                Optional.empty()));
 
     // Set up API responses
     when(wdsService.getRecord(recordType, recordId1))
@@ -860,7 +863,8 @@ class TestRunSetsApiController {
                 UUID.randomUUID(),
                 "method url",
                 workspaceId,
-                "develop"),
+                "develop",
+                Optional.empty()),
             "",
             "",
             false,
@@ -896,7 +900,8 @@ class TestRunSetsApiController {
                 UUID.randomUUID(),
                 "method url",
                 workspaceId,
-                "develop"),
+                "develop",
+                Optional.empty()),
             "",
             "",
             false,
@@ -972,7 +977,8 @@ class TestRunSetsApiController {
                 UUID.randomUUID(),
                 "method url",
                 workspaceId,
-                "test_branch"),
+                "test_branch",
+                Optional.empty()),
             "",
             "",
             false,
@@ -1055,7 +1061,8 @@ class TestRunSetsApiController {
                 UUID.randomUUID(),
                 "method url",
                 workspaceId,
-                "0.0.15"),
+                "0.0.15",
+                Optional.empty()),
             "",
             "",
             false,

--- a/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestRunsApiController.java
@@ -42,6 +42,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -109,7 +110,8 @@ class TestRunsApiController {
               runSetId,
               "methodurl",
               workspaceId,
-              "develop"),
+              "develop",
+              Optional.empty()),
           "runSetName",
           "runSetDescription",
           true,

--- a/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestMethodDao.java
@@ -13,6 +13,7 @@ import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,8 @@ class TestMethodDao extends ContainerizedDatabaseTest {
           null,
           "https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
   RunSet runSet =
       new RunSet(
           UUID.randomUUID(),

--- a/service/src/test/java/bio/terra/cbas/dao/TestMethodVersionDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestMethodVersionDao.java
@@ -11,6 +11,7 @@ import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,8 @@ class TestMethodVersionDao extends ContainerizedDatabaseTest {
           null,
           methodUrl,
           workspaceId,
-          branch);
+          branch,
+          Optional.empty());
 
   RunSet runSet =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -15,6 +15,7 @@ import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,8 @@ class TestRunDao extends ContainerizedDatabaseTest {
           null,
           "https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   RunSet runSet =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import bio.terra.cbas.dao.util.ContainerizedDatabaseTest;
 import bio.terra.cbas.models.CbasRunSetStatus;
 import bio.terra.cbas.models.CbasRunStatus;
+import bio.terra.cbas.models.GithubMethodVersionDetails;
 import bio.terra.cbas.models.Method;
 import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.Run;
@@ -39,9 +40,11 @@ class TestRunDao extends ContainerizedDatabaseTest {
           "Github",
           workspaceId);
 
+  String methodVersionGithash = "abcd123";
+  UUID methodVersionId = UUID.randomUUID();
   MethodVersion methodVersion =
       new MethodVersion(
-          UUID.randomUUID(),
+          methodVersionId,
           method,
           "1.0",
           "fetch_sra_to_bam sample submission",
@@ -50,7 +53,7 @@ class TestRunDao extends ContainerizedDatabaseTest {
           "https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl",
           workspaceId,
           "develop",
-          Optional.empty());
+          Optional.of(new GithubMethodVersionDetails(methodVersionGithash, methodVersionId)));
 
   RunSet runSet =
       new RunSet(
@@ -108,6 +111,12 @@ class TestRunDao extends ContainerizedDatabaseTest {
       assertEquals(run.engineId(), actual.engineId());
       assertEquals(run.errorMessages(), actual.errorMessages());
       assertEquals(run.status(), actual.status());
+
+      // Make sure the deep linking with method version details is working:
+      assertEquals(
+          methodVersionGithash,
+          run.runSet().methodVersion().methodVersionDetails().get().githash());
+
     } finally {
       try {
         int runsDeleted = runDao.deleteRun(run.runId());
@@ -140,6 +149,10 @@ class TestRunDao extends ContainerizedDatabaseTest {
       assertEquals(run.engineId(), actual.engineId());
       assertEquals(run.errorMessages(), actual.errorMessages());
       assertEquals(run.status(), actual.status());
+      // Make sure the deep linking with method version details is working:
+      assertEquals(
+          methodVersionGithash,
+          run.runSet().methodVersion().methodVersionDetails().get().githash());
     } finally {
       try {
         int runsDeleted = runDao.deleteRun(run.runId());
@@ -162,6 +175,10 @@ class TestRunDao extends ContainerizedDatabaseTest {
       List<Run> result =
           runDao.getRuns(new RunDao.RunsFilters(null, null, UUID.randomUUID().toString()));
       assertEquals(Collections.emptyList(), result);
+      // Make sure the deep linking with method version details is working:
+      assertEquals(
+          methodVersionGithash,
+          run.runSet().methodVersion().methodVersionDetails().get().githash());
     } finally {
       try {
         int runsDeleted = runDao.deleteRun(run.runId());

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunSetDao.java
@@ -12,6 +12,7 @@ import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,8 @@ class TestRunSetDao extends ContainerizedDatabaseTest {
           null,
           "https://raw.githubusercontent.com/broadinstitute/viral-pipelines/master/pipes/WDL/workflows/fetch_sra_to_bam.wdl",
           workspaceId,
-          "develop");
+          "develop",
+          Optional.empty());
 
   RunSet runSet =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/dao/util/ContainerizedDatabaseTest.java
+++ b/service/src/test/java/bio/terra/cbas/dao/util/ContainerizedDatabaseTest.java
@@ -51,6 +51,11 @@ public abstract class ContainerizedDatabaseTest {
             postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())
         .createStatement()
         .execute(
-            "TRUNCATE TABLE run CASCADE; TRUNCATE TABLE method_version CASCADE; TRUNCATE TABLE run_set CASCADE; TRUNCATE TABLE method CASCADE; TRUNCATE TABLE github_method_details CASCADE");
+            "TRUNCATE TABLE run CASCADE; "
+                + "TRUNCATE TABLE method_version CASCADE; "
+                + "TRUNCATE TABLE run_set CASCADE; "
+                + "TRUNCATE TABLE method CASCADE; "
+                + "TRUNCATE TABLE github_method_details CASCADE; "
+                + "TRUNCATE TABLE github_method_version_details CASCADE; ");
   }
 }

--- a/service/src/test/java/bio/terra/cbas/initialization/TestCloneRecoveryService.java
+++ b/service/src/test/java/bio/terra/cbas/initialization/TestCloneRecoveryService.java
@@ -16,6 +16,7 @@ import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.RunSet;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,8 @@ public class TestCloneRecoveryService {
           null,
           "",
           originalWorkspaceId,
-          "");
+          "",
+          Optional.empty());
 
   RunSet clonedTemplate =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/initialization/TestCloneRecoveryTransactionService.java
+++ b/service/src/test/java/bio/terra/cbas/initialization/TestCloneRecoveryTransactionService.java
@@ -16,6 +16,7 @@ import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,8 @@ public class TestCloneRecoveryTransactionService {
 
   Method method = new Method(UUID.randomUUID(), "", "", null, null, "", null);
   MethodVersion methodVersion =
-      new MethodVersion(UUID.randomUUID(), method, "", "", null, null, "", null, "");
+      new MethodVersion(
+          UUID.randomUUID(), method, "", "", null, null, "", null, "", Optional.empty());
 
   RunSet runSet =
       new RunSet(

--- a/service/src/test/java/bio/terra/cbas/pact/VerifyPactsAllControllers.java
+++ b/service/src/test/java/bio/terra/cbas/pact/VerifyPactsAllControllers.java
@@ -53,6 +53,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
@@ -198,7 +199,8 @@ class VerifyPactsAllControllers {
             fixedLastRunSetUUIDForMethod,
             "https://github.com/broadinstitute/warp/blob/develop/pipelines/skylab/scATAC/scATAC.wdl",
             workspaceId,
-            "develop");
+            "develop",
+            Optional.empty());
 
     // Arrange DAO responses
     when(methodVersionDao.getMethodVersion(any())).thenReturn(myMethodVersion);
@@ -266,7 +268,8 @@ class VerifyPactsAllControllers {
             UUID.randomUUID(),
             "https://raw.githubusercontent.com/broadinstitute/warp/develop/pipelines/skylab/scATAC/scATAC.wdl",
             workspaceId,
-            "develop");
+            "develop",
+            Optional.empty());
 
     RunSet targetRunSet =
         new RunSet(

--- a/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/monitoring/TestSmartRunsPollerFunctional.java
@@ -40,6 +40,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,7 +118,8 @@ public class TestSmartRunsPollerFunctional {
               runSetId,
               "file:///method/source/url",
               workspaceId,
-              "develop"),
+              "develop",
+              Optional.empty()),
           "runSetName",
           "runSetDescription",
           true,

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerFunctional.java
@@ -37,6 +37,7 @@ import cromwell.client.model.RunLog;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedata.client.ApiException;
 import org.junit.jupiter.api.BeforeEach;
@@ -483,7 +484,8 @@ class TestRunCompletionHandlerFunctional {
             runSetId,
             "file:///method/source/url",
             workspaceId,
-            "develop"),
+            "develop",
+            Optional.empty()),
         "runSetName",
         "runSetDescription",
         true,

--- a/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
+++ b/service/src/test/java/bio/terra/cbas/runsets/results/TestRunCompletionHandlerUnit.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.google.gson.Gson;
 import cromwell.client.model.RunLog;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import org.databiosphere.workspacedata.model.RecordAttributes;
 import org.junit.jupiter.api.Assertions;
@@ -91,7 +92,8 @@ class TestRunCompletionHandlerUnit {
               runSetId,
               "file:///method/source/url",
               workspaceId,
-              "develop"),
+              "develop",
+              Optional.empty()),
           "runSetName",
           "runSetDescription",
           true,
@@ -127,7 +129,8 @@ class TestRunCompletionHandlerUnit {
               runSetId,
               "file:///method/source/url",
               workspaceId,
-              "develop"),
+              "develop",
+              Optional.empty()),
           "runSetName",
           "runSetDescription",
           true,


### PR DESCRIPTION
Adds:
- `GithubMethodVersionDetails` table to store github-specific fields
- Inside that, a required githash field.

Updates:
- DAO methods to store (or not store) the field
- DAO methods to retrieve (or not retrieve) the field
- Test methods to make sure the retrieval is working properly

Note: as part of this ticket I ended up removing a couple of unexpected (and redundant?) GROUP BY constructs from various queries. The tests we have are all still passing. Question for reviewers: do these updates seem correct?