### PR TITLE
WM-2661: Add buildInfo to info endpoint

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -12,6 +12,10 @@ plugins {
 apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 
+springBoot {
+    buildInfo()
+}
+
 dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation "io.prometheus:simpleclient_httpserver"


### PR DESCRIPTION
Example API output below.

Note 1: The `version` field is the one we care about
Note 2: Yeah it would be cool to have git too, but not in this PR!

Before:
```json
{
  "git": {

  }
}
```

After:
```json
{
  "git": {

  },
  "build": {
    "artifact": "service",
    "name": "service",
    "time": "2024-06-03T18:31:45.429Z",
    "version": "0.0.221",
    "group": "bio.terra"
  }
}
```