### PR TITLE
WM-2584: Make run creation and updating error-length-safe

### DIFF
--- a/service/src/main/java/bio/terra/cbas/dao/RunDao.java
+++ b/service/src/main/java/bio/terra/cbas/dao/RunDao.java
@@ -3,6 +3,7 @@ package bio.terra.cbas.dao;
 import static bio.terra.cbas.dao.MethodDao.METHOD_JOIN_GITHUB_METHOD_DETAILS;
 import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_GITHUB_METHOD_VERSION_DETAILS;
 import static bio.terra.cbas.dao.MethodVersionDao.METHOD_VERSION_JOIN_METHOD;
+import static bio.terra.cbas.models.Run.truncatedErrorMessage;
 
 import bio.terra.cbas.common.DateUtils;
 import bio.terra.cbas.dao.mappers.RunSetMapper;
@@ -109,14 +110,6 @@ public class RunDao {
                 lastModifiedTimestamp,
                 Run.LAST_POLLED_TIMESTAMP_COL,
                 currentTimestamp)));
-  }
-
-  static String truncatedErrorMessage(String errorMessage) {
-    int maxChars = 1000;
-    if (errorMessage == null) {
-      return null;
-    }
-    return errorMessage.substring(0, Math.min(errorMessage.length(), maxChars));
   }
 
   public int updateRunStatusWithError(

--- a/service/src/main/java/bio/terra/cbas/models/Run.java
+++ b/service/src/main/java/bio/terra/cbas/models/Run.java
@@ -14,6 +14,35 @@ public record Run(
     OffsetDateTime lastPolledTimestamp,
     String errorMessages) {
 
+  public static String truncatedErrorMessage(String errorMessage) {
+    int maxChars = 1000;
+    if (errorMessage == null) {
+      return null;
+    }
+    return errorMessage.substring(0, Math.min(errorMessage.length(), maxChars));
+  }
+
+  public Run(
+      UUID runId,
+      String engineId,
+      RunSet runSet,
+      String recordId,
+      OffsetDateTime submissionTimestamp,
+      CbasRunStatus status,
+      OffsetDateTime lastModifiedTimestamp,
+      OffsetDateTime lastPolledTimestamp,
+      String errorMessages) {
+    this.runId = runId;
+    this.engineId = engineId;
+    this.runSet = runSet;
+    this.recordId = recordId;
+    this.submissionTimestamp = submissionTimestamp;
+    this.status = status;
+    this.lastModifiedTimestamp = lastModifiedTimestamp;
+    this.lastPolledTimestamp = lastPolledTimestamp;
+    this.errorMessages = truncatedErrorMessage(errorMessages);
+  }
+
   // Corresponding table column names in database
   public static final String RUN_ID_COL = "run_id";
   public static final String RUN_SET_ID_COL = "run_set_id";
@@ -55,19 +84,6 @@ public record Run(
         errorMessages);
   }
 
-  public Run withErrorMessage(String message) {
-    return new Run(
-        runId,
-        engineId,
-        runSet,
-        recordId,
-        submissionTimestamp,
-        status,
-        lastModifiedTimestamp,
-        lastPolledTimestamp,
-        message);
-  }
-
   public Run withLastModified(OffsetDateTime newLastModifiedTimestamp) {
     return new Run(
         runId,
@@ -104,6 +120,6 @@ public record Run(
         status,
         lastModifiedTimestamp,
         lastPolledTimestamp,
-        newErrorMessages);
+        truncatedErrorMessage(newErrorMessages));
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/RunSetAbortManager.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/RunSetAbortManager.java
@@ -7,6 +7,7 @@ import bio.terra.cbas.dao.RunDao;
 import bio.terra.cbas.dao.RunSetDao;
 import bio.terra.cbas.dependencies.wes.CromwellService;
 import bio.terra.cbas.models.CbasRunSetStatus;
+import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.Run;
 import bio.terra.cbas.models.RunSet;
 import bio.terra.common.iam.BearerToken;
@@ -58,8 +59,9 @@ public class RunSetAbortManager {
         String msg = "Unable to abort workflow %s.".formatted(run.runId());
         log.error(msg, e);
         failedRunIds.add(run.runId().toString());
-        // Add the error message against the run
-        run.withErrorMessage(msg);
+        // Record the error message against the run:
+        runDao.updateRunStatusWithError(
+            run.runId(), CbasRunStatus.SYSTEM_ERROR, OffsetDateTime.now(), msg);
       }
     }
 

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunDao.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class TestRunDao extends ContainerizedDatabaseTest {
@@ -197,5 +199,71 @@ class TestRunDao extends ContainerizedDatabaseTest {
   void getRunByEngineIdIfExistsNullEngineIdNotFound() {
     List<Run> result = runDao.getRuns(new RunDao.RunsFilters(null, null, null));
     assertEquals(Collections.emptyList(), result);
+  }
+
+  @ParameterizedTest()
+  @ValueSource(ints = {5, 100, 1000, 10000, 1000000})
+  void safelyTruncatesLongErrorMessagesForInitialStorage(int length) {
+    String longErrorMessage = "a".repeat(length);
+    Run runWithLongErrorMessage1 =
+        new Run(
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            runSet,
+            null,
+            OffsetDateTime.parse("2023-01-27T19:21:24.563932Z"),
+            CbasRunStatus.INITIALIZING,
+            OffsetDateTime.parse("2023-01-27T19:21:24.563932Z"),
+            OffsetDateTime.parse("2023-01-27T19:21:24.563932Z"),
+            longErrorMessage);
+
+    Run runWithLongErrorMessage2 = run.withErrorMessages(longErrorMessage);
+
+    try {
+      runSetDao.createRunSet(runSet);
+      runDao.createRun(runWithLongErrorMessage1);
+      runDao.createRun(runWithLongErrorMessage2);
+
+      List<Run> result = runDao.getRuns(new RunDao.RunsFilters(null, null, null));
+      assertNotNull(result);
+      assertEquals(2, (long) result.size());
+    } finally {
+      try {
+        int runsDeleted = runDao.deleteRun(runWithLongErrorMessage1.runId());
+        runsDeleted += runDao.deleteRun(runWithLongErrorMessage2.runId());
+        int runSetsDeleted = runSetDao.deleteRunSet(runSet.runSetId());
+
+        assertEquals(2, runsDeleted);
+        assertEquals(1, runSetsDeleted);
+      } catch (Exception ex) {
+        fail("Failure while removing test run from a database", ex);
+      }
+    }
+  }
+
+  @ParameterizedTest()
+  @ValueSource(ints = {5, 100, 1000, 10000, 1000000})
+  void safelyTruncatesLongErrorMessagesDuringUpdate(int length) {
+    String longErrorMessage = "a".repeat(length);
+
+    try {
+      runSetDao.createRunSet(runSet);
+      runDao.createRun(run);
+      int updated =
+          runDao.updateRunStatusWithError(
+              run.runId(), CbasRunStatus.SYSTEM_ERROR, OffsetDateTime.now(), longErrorMessage);
+
+      assertEquals(1, updated);
+    } finally {
+      try {
+        int runsDeleted = runDao.deleteRun(run.runId());
+        int runSetsDeleted = runSetDao.deleteRunSet(runSet.runSetId());
+
+        assertEquals(1, runsDeleted);
+        assertEquals(1, runSetsDeleted);
+      } catch (Exception ex) {
+        fail("Failure while removing test run from a database", ex);
+      }
+    }
   }
 }

--- a/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
+++ b/service/src/test/java/bio/terra/cbas/dao/TestRunsFilters.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.cbas.dao.RunDao.RunsFilters;
 import bio.terra.cbas.dao.util.WhereClause;
 import bio.terra.cbas.models.CbasRunStatus;
+import bio.terra.cbas.models.Run;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -139,7 +140,7 @@ class TestRunsFilters {
   @Test
   void truncateTooShortMessage() {
     String message = "This is a short message";
-    String actual = RunDao.truncatedErrorMessage(message);
+    String actual = Run.truncatedErrorMessage(message);
     assertEquals(message, actual);
     assertEquals(23, actual.length());
   }
@@ -148,7 +149,7 @@ class TestRunsFilters {
   void truncateExactLengthMessage() {
 
     String inputString = "a".repeat(1000);
-    String actual = RunDao.truncatedErrorMessage(inputString);
+    String actual = Run.truncatedErrorMessage(inputString);
 
     assertEquals(inputString, actual);
     assertEquals(1000, actual.length());
@@ -160,7 +161,7 @@ class TestRunsFilters {
     String inputString = "a".repeat(1025);
     String expectedString = "a".repeat(1000);
 
-    String actual = RunDao.truncatedErrorMessage(inputString);
+    String actual = Run.truncatedErrorMessage(inputString);
 
     assertEquals(expectedString, actual);
     assertEquals(1000, actual.length());


### PR DESCRIPTION
Eventually we might want to raise or parameterize this length. In the mean time, make it safe