### PR TITLE
[WM-2643] Cromwell callback and smart poller metrics

### DIFF
--- a/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
+++ b/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
@@ -14,10 +14,17 @@ public class MicrometerMetrics {
     this.meterRegistry = meterRegistry;
   }
 
-  public void logRunCompletion(String completionTrigger, CbasRunStatus resultsStatus) {
+  public void logRunCallback( CbasRunStatus resultsStatus) {
     Counter counter =
-        Counter.builder("run_completion")
-            .tag("completion_trigger", completionTrigger)
+        Counter.builder("run_callback")
+            .tag("status", resultsStatus.toString())
+            .register(meterRegistry);
+    counter.increment();
+  }
+
+  public void logRunStatusUpdate(CbasRunStatus resultsStatus) {
+    Counter counter =
+        Counter.builder("run_status_update")
             .tag("status", resultsStatus.toString())
             .register(meterRegistry);
     counter.increment();

--- a/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
+++ b/service/src/main/java/bio/terra/cbas/common/MicrometerMetrics.java
@@ -14,7 +14,7 @@ public class MicrometerMetrics {
     this.meterRegistry = meterRegistry;
   }
 
-  public void logRunCallback( CbasRunStatus resultsStatus) {
+  public void logRunCallback(CbasRunStatus resultsStatus) {
     Counter counter =
         Counter.builder("run_callback")
             .tag("status", resultsStatus.toString())
@@ -24,7 +24,7 @@ public class MicrometerMetrics {
 
   public void logRunStatusUpdate(CbasRunStatus resultsStatus) {
     Counter counter =
-        Counter.builder("run_status_update")
+        Counter.builder("run_smartpoller_update")
             .tag("status", resultsStatus.toString())
             .register(meterRegistry);
     counter.increment();

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -149,7 +149,7 @@ public class RunsApiController implements RunsApi {
         runCompletionHandler.updateResults(
             runRecord.get(), resultsStatus, body.getOutputs(), failures, userToken);
 
-    micrometerMetrics.logRunCompletion("callback", resultsStatus);
+    micrometerMetrics.logRunCallback(resultsStatus);
     return new ResponseEntity<>(result.toHttpStatus());
   }
 }

--- a/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/RunsApiController.java
@@ -150,6 +150,7 @@ public class RunsApiController implements RunsApi {
             runRecord.get(), resultsStatus, body.getOutputs(), failures, userToken);
 
     micrometerMetrics.logRunCallback(resultsStatus);
+
     return new ResponseEntity<>(result.toHttpStatus());
   }
 }

--- a/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
+++ b/service/src/main/java/bio/terra/cbas/runsets/monitoring/SmartRunsPoller.java
@@ -205,8 +205,10 @@ public class SmartRunsPoller {
           errors.addAll(cromwellErrors);
         }
       }
+
+      micrometerMetrics.logRunStatusUpdate(updatedRunState);
+
       // Call Run Completion handler to update results
-      micrometerMetrics.logRunCompletion("smartpoller", updatedRunState);
       var updateResult =
           runCompletionHandler.updateResults(
               updatableRun, updatedRunState, outputs, errors, engineStatusChanged, userToken);


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WM-2643

The PR splits the `run_completion` metric, which was recording both the smart poller and callback metrics, into 2 metrics. 

Tested changes by manually updating CBAS image in dev app
![Screenshot 2024-06-14 at 11 50 20 AM](https://github.com/DataBiosphere/cbas/assets/16748522/966edbe8-9ff1-40a1-96ab-0bbcb650c7ad)
