### PR TITLE
[WM-2670] Runs submitted to Cromwell are marked in Initializing status in CBAS

### DIFF
--- a/service/src/main/java/bio/terra/cbas/models/CbasRunStatus.java
+++ b/service/src/main/java/bio/terra/cbas/models/CbasRunStatus.java
@@ -75,7 +75,7 @@ public enum CbasRunStatus {
 
   public static CbasRunStatus fromCromwellStatus(String status) {
     return switch (status) {
-      case "Submitted" -> CbasRunStatus.QUEUED;
+      case "Submitted" -> CbasRunStatus.INITIALIZING;
       case "Running" -> CbasRunStatus.RUNNING;
       case "Aborting" -> CbasRunStatus.CANCELING;
       case "Aborted" -> CbasRunStatus.CANCELED;

--- a/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
+++ b/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
@@ -1,0 +1,24 @@
+package bio.terra.cbas.models;
+
+import static bio.terra.cbas.models.CbasRunStatus.fromCromwellStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestCbasRunStatus {
+
+  @ParameterizedTest(name = "")
+  @CsvSource({
+    "Submitted,INITIALIZING",
+    "Running,RUNNING",
+    "Aborting,CANCELING",
+    "Aborted,CANCELED",
+    "Failed,EXECUTOR_ERROR",
+    "Succeeded,COMPLETE",
+    "MyCromwellStatus,UNKNOWN"
+  })
+  void testFromCromwellStatus(String cromwellStatus, CbasRunStatus cbasStatus) {
+    assertEquals(cbasStatus, fromCromwellStatus(cromwellStatus));
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
+++ b/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestCbasRunStatus {
 
-  @ParameterizedTest(name = "")
+  @ParameterizedTest()
   @CsvSource({
     "Submitted,INITIALIZING",
     "Running,RUNNING",

--- a/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
+++ b/service/src/test/java/bio/terra/cbas/models/TestCbasRunStatus.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-public class TestCbasRunStatus {
+class TestCbasRunStatus {
 
   @ParameterizedTest()
   @CsvSource({


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WM-2670

Current status transitions that was causing the workflow to revert back to Queued state mid-run:
- When a workflow is being processed in CBAS upon submission, it is marked in `Queued` state
- When CBAS submits that workflow to Cromwell, it is marked in `Initializing` state
- Now when Cromwell receives a workflow it stores the workflow in DB in `Submitted` state 
- When CBAS polls for status update it would mark the same run back to `Queued` state because of the mapping in `fromCromwellStatus()` and as a result the status transitions were Queued -> Initializing -> Queued -> Running -> other states

Proposed changes:
When Cromwell returns a workflow in `Submitted` state, the corresponding CBAS status is now `Initializing` and hence the status transitions would be Queued -> Initializing -> Running -> other states
