### PR TITLE
[WM-2642] refactor submission methods

### DIFF
--- a/service/src/main/java/bio/terra/cbas/models/RunAndRecordDetails.java
+++ b/service/src/main/java/bio/terra/cbas/models/RunAndRecordDetails.java
@@ -1,0 +1,6 @@
+package bio.terra.cbas.models;
+
+import java.util.UUID;
+import org.databiosphere.workspacedata.model.RecordResponse;
+
+public record RunAndRecordDetails(UUID runId, RecordResponse recordResponse) {}

--- a/service/src/main/java/bio/terra/cbas/models/RunSetSubmissionParameters.java
+++ b/service/src/main/java/bio/terra/cbas/models/RunSetSubmissionParameters.java
@@ -1,0 +1,16 @@
+package bio.terra.cbas.models;
+
+import bio.terra.cbas.model.RunStateResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.databiosphere.workspacedata.model.RecordResponse;
+
+public record RunSetSubmissionParameters(
+    RunSet runSet,
+    String rawMethodUrl,
+    String workflowOptionsJson,
+    List<Map<UUID, String>> batchedWorkflowInputMaps,
+    List<Map<UUID, RunAndRecordDetails>> batchedRunAndRecordMaps,
+    List<List<RecordResponse>> batches,
+    List<RunStateResponse> runStateErrors) {}

--- a/service/src/main/java/bio/terra/cbas/models/SubmitRunSetResponse.java
+++ b/service/src/main/java/bio/terra/cbas/models/SubmitRunSetResponse.java
@@ -3,5 +3,5 @@ package bio.terra.cbas.models;
 import bio.terra.cbas.model.RunStateResponse;
 import java.util.List;
 
-public record SubmitRunResponse(
+public record SubmitRunSetResponse(
     List<RunStateResponse> runStateResponseList, List<String> successfullyInitializedWorkflowIds) {}

--- a/service/src/main/java/bio/terra/cbas/service/RunSetsService.java
+++ b/service/src/main/java/bio/terra/cbas/service/RunSetsService.java
@@ -29,8 +29,10 @@ import bio.terra.cbas.models.CbasRunStatus;
 import bio.terra.cbas.models.GithubMethodDetails;
 import bio.terra.cbas.models.MethodVersion;
 import bio.terra.cbas.models.Run;
+import bio.terra.cbas.models.RunAndRecordDetails;
 import bio.terra.cbas.models.RunSet;
-import bio.terra.cbas.models.SubmitRunResponse;
+import bio.terra.cbas.models.RunSetSubmissionParameters;
+import bio.terra.cbas.models.SubmitRunSetResponse;
 import bio.terra.cbas.runsets.inputs.InputGenerator;
 import bio.terra.cbas.runsets.types.CoercionException;
 import bio.terra.cbas.util.UuidSource;
@@ -100,8 +102,6 @@ public class RunSetsService {
     this.micrometerMetrics = micrometerMetrics;
     this.bardService = bardService;
   }
-
-  private record RunAndRecordDetails(UUID runId, RecordResponse recordResponse) {}
 
   public RunSet registerRunSet(
       RunSetRequest runSetRequest, UserStatusInfo user, MethodVersion methodVersion)
@@ -206,17 +206,19 @@ public class RunSetsService {
     }
 
     // For each Record ID, build workflow inputs and submit the workflow to Cromwell
-    SubmitRunResponse runStateResponse =
-        buildInputsAndSubmitRunSet(
-            cromwellService,
+    RunSetSubmissionParameters params =
+        buildInputs(
             request,
             runSet,
-            wdsRecordResponses.recordResponseList(),
             rawMethodUrl,
+            wdsRecordResponses.recordResponseList(),
             recordIdToRunIdMapping,
-            requestTimerSample,
-            userToken);
-    List<RunStateResponse> runStateResponseList = runStateResponse.runStateResponseList();
+            cromwellService);
+
+    SubmitRunSetResponse runSetStateResponse =
+        submitRunSet(params, userToken, cromwellService, requestTimerSample);
+
+    List<RunStateResponse> runStateResponseList = runSetStateResponse.runStateResponseList();
 
     // Figure out how many runs are in Failed state. If all Runs are in an Error state then mark
     // the Run Set as Failed
@@ -237,7 +239,10 @@ public class RunSetsService {
         runsInErrorState.size(),
         OffsetDateTime.now());
     logRunSetEvent(
-        request, methodVersion, runStateResponse.successfullyInitializedWorkflowIds(), userToken);
+        request,
+        methodVersion,
+        runSetStateResponse.successfullyInitializedWorkflowIds(),
+        userToken);
   }
 
   private WdsRecordResponseDetails fetchWdsRecords(
@@ -295,28 +300,29 @@ public class RunSetsService {
         runSetId, CbasRunSetStatus.ERROR, runsCount, runsCount, OffsetDateTime.now());
   }
 
-  private SubmitRunResponse buildInputsAndSubmitRunSet(
-      CromwellService cromwellService,
+  private RunSetSubmissionParameters buildInputs(
       RunSetRequest request,
       RunSet runSet,
+      String methodUrl,
       List<RecordResponse> recordResponses,
-      String rawMethodUrl,
       Map<String, UUID> recordIdToRunIdMapping,
-      Timer.Sample cromwellRequestTimerSample,
-      BearerToken userToken) {
-    ArrayList<RunStateResponse> runStateResponseList = new ArrayList<>();
-    ArrayList<String> successfullyInitializedWorkflowIds = new ArrayList<>();
+      CromwellService cromwellService) {
+
+    ArrayList<RunStateResponse> runStateResponseErrors = new ArrayList<>();
+
     // Build the JSON that specifies additional configuration for cromwell workflows. The same
     // options will be used for all workflows submitted as part of this run set.
     String workflowOptionsJson =
         cromwellService.buildWorkflowOptionsJson(
             Objects.requireNonNullElse(runSet.callCachingEnabled(), true));
 
-    Timer.Sample cromwellSubmitRunsSample = micrometerMetrics.startTimer();
     List<List<RecordResponse>> batches =
         Lists.partition(recordResponses, cbasApiConfiguration.getMaxWorkflowsInBatch());
-    for (int batchIdx = 0; batchIdx < batches.size(); batchIdx += 1) {
-      List<RecordResponse> batch = batches.get(batchIdx);
+
+    List<Map<UUID, String>> batchedWorkflowInputMaps = new ArrayList<>();
+    List<Map<UUID, RunAndRecordDetails>> batchedRunAndRecordMaps = new ArrayList<>();
+
+    for (List<RecordResponse> batch : batches) {
       // create a mapping from Engine ID -> class RunAndRecordDetails[Run ID, Record Response]
       Map<UUID, RunAndRecordDetails> engineIdToRunAndRecordMapping =
           batch.stream()
@@ -327,6 +333,8 @@ public class RunSetsService {
                           new RunAndRecordDetails(
                               recordIdToRunIdMapping.get(singleRecord.getId()), singleRecord)))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      batchedRunAndRecordMaps.add(engineIdToRunAndRecordMapping);
 
       // Build the inputs set from workflow parameter definitions and the fetched record
       Map<UUID, String> engineIdToWorkflowInput =
@@ -339,19 +347,19 @@ public class RunSetsService {
                           InputGenerator.inputsToJson(
                               InputGenerator.buildInputs(
                                   request.getWorkflowInputDefinitions(),
-                                  entry.getValue().recordResponse)));
+                                  entry.getValue().recordResponse())));
                     } catch (CoercionException e) {
                       String errorMsg =
                           String.format(
                               "Input generation failed for record %s. Coercion error: %s",
-                              entry.getValue().recordResponse.getId(), e.getMessage());
+                              entry.getValue().recordResponse().getId(), e.getMessage());
                       logger.warn(errorMsg, e);
-                      runStateResponseList.add(
-                          recordFailureToStartRun(entry.getValue().runId, errorMsg));
+                      runStateResponseErrors.add(
+                          recordFailureToStartRun(entry.getValue().runId(), errorMsg));
                     } catch (InputProcessingException e) {
                       logger.warn(e.getMessage());
-                      runStateResponseList.add(
-                          recordFailureToStartRun(entry.getValue().runId, e.getMessage()));
+                      runStateResponseErrors.add(
+                          recordFailureToStartRun(entry.getValue().runId(), e.getMessage()));
                     } catch (JsonProcessingException e) {
                       // Should be super rare that jackson cannot convert an object to Json...
                       String errorMsg =
@@ -359,16 +367,49 @@ public class RunSetsService {
                               "Failed to convert inputs object to JSON for batch in RunSet %s.",
                               runSet.runSetId());
                       logger.warn(errorMsg, e);
-                      runStateResponseList.add(
-                          recordFailureToStartRun(entry.getValue().runId, errorMsg));
+                      runStateResponseErrors.add(
+                          recordFailureToStartRun(entry.getValue().runId(), errorMsg));
                     }
                     return null;
                   })
               .filter(inputs -> !Objects.isNull(inputs))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+      batchedWorkflowInputMaps.add(engineIdToWorkflowInput);
+    }
+
+    return new RunSetSubmissionParameters(
+        runSet,
+        methodUrl,
+        workflowOptionsJson,
+        batchedWorkflowInputMaps,
+        batchedRunAndRecordMaps,
+        batches,
+        runStateResponseErrors);
+  }
+
+  private SubmitRunSetResponse submitRunSet(
+      RunSetSubmissionParameters params,
+      BearerToken userToken,
+      CromwellService cromwellService,
+      Timer.Sample cromwellRequestTimerSample) {
+    RunSet runSet = params.runSet();
+    String rawMethodUrl = params.rawMethodUrl();
+    String workflowOptionsJson = params.workflowOptionsJson();
+    List<Map<UUID, String>> batchedWorkflowInputMaps = params.batchedWorkflowInputMaps();
+    List<Map<UUID, RunAndRecordDetails>> batchedRunAndRecordMaps = params.batchedRunAndRecordMaps();
+    List<List<RecordResponse>> batches = params.batches();
+    ArrayList<RunStateResponse> runStateResponseList = new ArrayList<>(params.runStateErrors());
+    ArrayList<String> successfullyInitializedWorkflowIds = new ArrayList<>();
+
+    Timer.Sample cromwellSubmitRunsSample = micrometerMetrics.startTimer();
+
+    for (int batchIdx = 0; batchIdx < batches.size(); batchIdx += 1) {
+      Map<UUID, String> engineIdToWorkflowInput = batchedWorkflowInputMaps.get(batchIdx);
+      Map<UUID, RunAndRecordDetails> engineIdToRunAndRecordMapping =
+          batchedRunAndRecordMaps.get(batchIdx);
       if (engineIdToWorkflowInput.isEmpty()) {
-        return new SubmitRunResponse(runStateResponseList, List.of());
+        return new SubmitRunSetResponse(runStateResponseList, List.of());
       }
 
       try {
@@ -403,7 +444,7 @@ public class RunSetsService {
                       UUID engineId = UUID.fromString(idAndStatus.getId());
                       successfullyInitializedWorkflowIds.add(engineId.toString());
                       return recordSuccessInitializingRun(
-                          engineIdToRunAndRecordMapping.get(engineId).runId, engineId);
+                          engineIdToRunAndRecordMapping.get(engineId).runId(), engineId);
                     })
                 .toList());
       } catch (cromwell.client.ApiException e) {
@@ -417,7 +458,7 @@ public class RunSetsService {
                 .map(
                     engineId ->
                         recordFailureToStartRun(
-                            engineIdToRunAndRecordMapping.get(engineId).runId,
+                            engineIdToRunAndRecordMapping.get(engineId).runId(),
                             errorMsg + e.getMessage()))
                 .toList());
       }
@@ -430,7 +471,7 @@ public class RunSetsService {
         runSet.runSetId().toString(),
         "runStateResponseList",
         runStateResponseList.toString());
-    return new SubmitRunResponse(runStateResponseList, successfullyInitializedWorkflowIds);
+    return new SubmitRunSetResponse(runStateResponseList, successfullyInitializedWorkflowIds);
   }
 
   public HashMap<String, String> getRunSetEventProperties(


### PR DESCRIPTION
These refactors address sonarcloud's "cognitive complexity" warnings in [WM-2642_submission-scaling-metrics](https://github.com/DataBiosphere/cbas/tree/WM-2642_submission-scaling-metrics) by splitting `buildInputsAndSubmitRunSet` into two methods, `buildInputs` and `submitRunSet`