### PR TITLE
[WM-2683] Adds /capabilities API

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java-library-conventions'
     id 'maven-publish'
     id 'io.spring.dependency-management'
-    id 'com.jfrog.artifactory' version '4.18.2'
+    id 'com.jfrog.artifactory' version '5.2.3'
     id 'org.hidetake.swagger.generator'
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java-library-conventions'
     id 'maven-publish'
     id 'io.spring.dependency-management'
-    id 'com.jfrog.artifactory' version '5.2.3'
+    id 'com.jfrog.artifactory' version '4.18.2'
     id 'org.hidetake.swagger.generator'
 }
 

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -197,6 +197,20 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /capabilities/v1:
+    get:
+      summary: Describes the capabilities of this CBAS version
+      tags: [ public ]
+      operationId: capabilities
+      security: [ ]
+      responses:
+        200:
+          description: JSON object describing capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+
 components:
   requestBodies:
     PostRunSetRequest:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -209,7 +209,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/CapabilitiesResponse'
 
 components:
   requestBodies:
@@ -968,3 +968,10 @@ components:
         - Failed
         - Aborted
       type: string
+
+    CapabilitiesResponse:
+      type: object
+      additionalProperties: true
+      example:
+        submission.limits.maxWorkflows: 100
+        workflow.archiving: true

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -974,4 +974,4 @@ components:
       additionalProperties: true
       example:
         submission.limits.maxWorkflows: 100
-        workflow.archiving: true
+        new-feature-namespace.feature-name: true

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -2,6 +2,7 @@ package bio.terra.cbas.controllers;
 
 import bio.terra.cbas.api.PublicApi;
 import bio.terra.cbas.dependencies.common.ScheduledHealthChecker;
+import bio.terra.cbas.model.CapabilitiesResponse;
 import bio.terra.cbas.model.SystemStatus;
 import bio.terra.cbas.model.SystemStatusSystems;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,16 +16,16 @@ import org.springframework.stereotype.Controller;
 public class PublicApiController implements PublicApi {
 
   private final ScheduledHealthChecker scheduledHealthChecker;
-  private final Object capabilitiesResponse;
+  private final CapabilitiesResponse capabilitiesResponse;
 
   @Autowired
   public PublicApiController(
       ScheduledHealthChecker scheduledHealthChecker, ObjectMapper objectMapper) {
     // read the "capabilities.json" file from resources and parse it into response object
     InputStream inputStream = getClass().getResourceAsStream("/capabilities.json");
-    Object tempCapabilitiesResponse;
+    CapabilitiesResponse tempCapabilitiesResponse;
     try {
-      tempCapabilitiesResponse = objectMapper.readValue(inputStream, Object.class);
+      tempCapabilitiesResponse = objectMapper.readValue(inputStream, CapabilitiesResponse.class);
       log.info("Capabilities in this CBAS version: {}", tempCapabilitiesResponse);
     } catch (Exception e) {
       log.error("Could not read 'capabilities.json' file. Error: {}", e.getMessage(), e);
@@ -53,7 +54,7 @@ public class PublicApiController implements PublicApi {
   }
 
   @Override
-  public ResponseEntity<Object> capabilities() {
+  public ResponseEntity<CapabilitiesResponse> capabilities() {
     if (capabilitiesResponse != null) {
       return new ResponseEntity<>(capabilitiesResponse, HttpStatus.OK);
     }

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -2,5 +2,6 @@
   "submission.limits.maxWorkflows" : 100,
   "submission.limits.maxInputs" : 200,
   "submission.limits.maxOutputs" : 300,
-  "workflow.archiving" : true
+  "workflow.archiving" : true,
+  "workflow.private_workflows.github" : true
 }

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -1,0 +1,6 @@
+{
+  "submission.limits.maxWorkflows" : 100,
+  "submission.limits.maxInputs" : 200,
+  "submission.limits.maxOutputs" : 300,
+  "workflow.archiving" : true
+}

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -1,7 +1,5 @@
 {
   "submission.limits.maxWorkflows" : 100,
   "submission.limits.maxInputs" : 200,
-  "submission.limits.maxOutputs" : 300,
-  "workflow.archiving" : true,
-  "workflow.private-workflows.github" : true
+  "submission.limits.maxOutputs" : 300
 }

--- a/service/src/main/resources/capabilities.json
+++ b/service/src/main/resources/capabilities.json
@@ -3,5 +3,5 @@
   "submission.limits.maxInputs" : 200,
   "submission.limits.maxOutputs" : 300,
   "workflow.archiving" : true,
-  "workflow.private_workflows.github" : true
+  "workflow.private-workflows.github" : true
 }

--- a/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.cbas.model.CapabilitiesResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,8 +36,9 @@ class TestPublicApiController {
     MvcResult mvcResult =
         mockMvc.perform(get(CAPABILITIES_API)).andExpect(status().isOk()).andReturn();
 
-    Map<String, Object> parsedResponse =
-        objectMapper.readValue(mvcResult.getResponse().getContentAsString(), Map.class);
+    CapabilitiesResponse parsedResponse =
+        objectMapper.readValue(
+            mvcResult.getResponse().getContentAsString(), CapabilitiesResponse.class);
 
     assertThat(parsedResponse).isNotNull();
 
@@ -45,6 +46,7 @@ class TestPublicApiController {
     assertEquals(200, parsedResponse.get("submission.limits.maxInputs"));
     assertEquals(300, parsedResponse.get("submission.limits.maxOutputs"));
     assertEquals(true, parsedResponse.get("workflow.archiving"));
+    assertEquals(true, parsedResponse.get("workflow.private_workflows.github"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
@@ -1,0 +1,56 @@
+package bio.terra.cbas.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TestPublicApiController {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+
+  @Value("classpath:capabilities.json")
+  Resource capabilitiesResource;
+
+  private static final String CAPABILITIES_API = "/capabilities/v1";
+
+  @Test
+  void successfullyReturnCapabilities() throws Exception {
+    MvcResult mvcResult =
+        mockMvc.perform(get(CAPABILITIES_API)).andExpect(status().isOk()).andReturn();
+
+    Map<String, Object> parsedResponse =
+        objectMapper.readValue(mvcResult.getResponse().getContentAsString(), Map.class);
+
+    assertThat(parsedResponse).isNotNull();
+
+    assertEquals(100, parsedResponse.get("submission.limits.maxWorkflows"));
+    assertEquals(200, parsedResponse.get("submission.limits.maxInputs"));
+    assertEquals(300, parsedResponse.get("submission.limits.maxOutputs"));
+    assertEquals(true, parsedResponse.get("workflow.archiving"));
+  }
+
+  @Test
+  void checkCapabilitiesJsonFileIsValid() {
+    assertDoesNotThrow(
+        () -> objectMapper.readValue(capabilitiesResource.getInputStream(), Object.class),
+        "Resource file 'capabilities.json' is invalid.");
+  }
+}

--- a/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
@@ -45,8 +45,6 @@ class TestPublicApiController {
     assertEquals(100, parsedResponse.get("submission.limits.maxWorkflows"));
     assertEquals(200, parsedResponse.get("submission.limits.maxInputs"));
     assertEquals(300, parsedResponse.get("submission.limits.maxOutputs"));
-    assertEquals(true, parsedResponse.get("workflow.archiving"));
-    assertEquals(true, parsedResponse.get("workflow.private-workflows.github"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
@@ -46,7 +46,7 @@ class TestPublicApiController {
     assertEquals(200, parsedResponse.get("submission.limits.maxInputs"));
     assertEquals(300, parsedResponse.get("submission.limits.maxOutputs"));
     assertEquals(true, parsedResponse.get("workflow.archiving"));
-    assertEquals(true, parsedResponse.get("workflow.private_workflows.github"));
+    assertEquals(true, parsedResponse.get("workflow.private-workflows.github"));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
+++ b/service/src/test/java/bio/terra/cbas/controllers/TestPublicApiController.java
@@ -2,7 +2,6 @@ package bio.terra.cbas.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,25 +31,25 @@ class TestPublicApiController {
   private static final String CAPABILITIES_API = "/capabilities/v1";
 
   @Test
-  void successfullyReturnCapabilities() throws Exception {
+  void checkCapabilitiesResponseIsValid() throws Exception {
     MvcResult mvcResult =
         mockMvc.perform(get(CAPABILITIES_API)).andExpect(status().isOk()).andReturn();
 
     CapabilitiesResponse parsedResponse =
-        objectMapper.readValue(
-            mvcResult.getResponse().getContentAsString(), CapabilitiesResponse.class);
+        assertDoesNotThrow(
+            () ->
+                objectMapper.readValue(
+                    mvcResult.getResponse().getContentAsString(), CapabilitiesResponse.class));
 
-    assertThat(parsedResponse).isNotNull();
-
-    assertEquals(100, parsedResponse.get("submission.limits.maxWorkflows"));
-    assertEquals(200, parsedResponse.get("submission.limits.maxInputs"));
-    assertEquals(300, parsedResponse.get("submission.limits.maxOutputs"));
+    assertThat(parsedResponse).isNotEmpty();
   }
 
   @Test
   void checkCapabilitiesJsonFileIsValid() {
     assertDoesNotThrow(
-        () -> objectMapper.readValue(capabilitiesResource.getInputStream(), Object.class),
+        () ->
+            objectMapper.readValue(
+                capabilitiesResource.getInputStream(), CapabilitiesResponse.class),
         "Resource file 'capabilities.json' is invalid.");
   }
 }


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WM-2683

This PR adds new `capabilities` API. The response is a JSON object that is defined in `capabilities.json` file. The response structure is [similar to WDS' capabilities API](https://github.com/DataBiosphere/terra-workspace-data-service/wiki/Capabilities-API#response-structure) where response is:
- flat list of key-value pairs where keys are strings and values should be primitive type
- keys use dot notation to group related keys into a namespace, e.g. `submission.limits`

Wiki documentation: https://github.com/DataBiosphere/cbas/wiki/Capabilities-API

Response:
```
{
  "submission.limits.maxOutputs": 300,
  "submission.limits.maxWorkflows": 100,
  "submission.limits.maxInputs": 200
}
```

TODO:

- [x] add documentation in Wiki page