### PR TITLE
[WM-2703] Upgrade 'com.jfrog.artifactory' version

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java-library-conventions'
     id 'maven-publish'
     id 'io.spring.dependency-management'
-    id 'com.jfrog.artifactory' version '4.18.2'
+    id 'com.jfrog.artifactory' version '5.2.3'
     id 'org.hidetake.swagger.generator'
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.srcclr.gradle'
     id 'org.sonarqube'
 
-    id 'com.gorylenko.gradle-git-properties' version '2.3.1'
+    id 'com.gorylenko.gradle-git-properties' version '2.4.2'
     id 'org.liquibase.gradle' version '2.1.0'
 }
 

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -21,6 +21,9 @@ public class PublicApiController implements PublicApi {
 
   @Override
   public ResponseEntity<SystemStatus> getStatus() {
+
+    System.out.println("TODO: remove this before merging");
+
     SystemStatus result = new SystemStatus().ok(true);
 
     scheduledHealthChecker

--- a/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
+++ b/service/src/main/java/bio/terra/cbas/controllers/PublicApiController.java
@@ -21,9 +21,6 @@ public class PublicApiController implements PublicApi {
 
   @Override
   public ResponseEntity<SystemStatus> getStatus() {
-
-    System.out.println("TODO: remove this before merging");
-
     SystemStatus result = new SystemStatus().ok(true);
 
     scheduledHealthChecker


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WM-2703

It seems all of a sudden pact tests started failing because build client wasn't able to find `build-info-extractor` POM file. This PR fixes that. I have upgraded CBAS to latest version of [com.jfrog.artifactory](https://github.com/jfrog/artifactory-gradle-plugin). This version is also [the one used by WDS](https://github.com/DataBiosphere/terra-workspace-data-service/blob/135b8301f34102e0dcde19c5a57857d07b663a6e/client/build.gradle#L6).
Failure:
```
A problem occurred configuring project ':client'.
> Could not resolve all files for configuration ':client:classpath'.
   > Could not find org.jfrog.buildinfo:build-info-extractor:2.21.0.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/org/jfrog/buildinfo/build-info-extractor/2.21.0/build-info-extractor-2.21.0.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :client > com.jfrog.artifactory:com.jfrog.artifactory.gradle.plugin:4.18.2 > org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2
```