### PR TITLE
[AN-1][AN-212] Upgrade base image to jre:17-12-distroless and spring-boot-gradle-plugin to 3.3.5

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.4'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.5'
     implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.5'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.3.4'
     implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -21,7 +21,7 @@ task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-12-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -10,11 +10,11 @@
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-<!--  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">-->
-<!--    <encoder>-->
-<!--      <pattern>${CONSOLE_LOG_PATTERN}</pattern>-->
-<!--    </encoder>-->
-<!--  </appender>-->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
 
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -6,9 +6,18 @@
 
   The console log pattern has been modified from the default to include request ID and user ID if present
   -->
-  <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint}%replace( %mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+<!--  <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(-&#45;&#45;){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint}%replace( %mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />-->
+<!--  <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} %level [%thread] %logger{36} - %msg%n" />-->
+<!--  <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } -&#45;&#45; [%15.15t] %-40.40logger{39} : %replace(%mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />-->
+  <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%15.15t] %-40.40logger{39} : %replace(%mdc - %msg){'  - ',' '}%n%ex" />
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
 
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -6,18 +6,15 @@
 
   The console log pattern has been modified from the default to include request ID and user ID if present
   -->
-<!--  <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(-&#45;&#45;){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint}%replace( %mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />-->
-<!--  <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} %level [%thread] %logger{36} - %msg%n" />-->
-<!--  <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } -&#45;&#45; [%15.15t] %-40.40logger{39} : %replace(%mdc - %msg){'  - ',' '}%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />-->
   <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%15.15t] %-40.40logger{39} : %replace(%mdc - %msg){'  - ',' '}%n%ex" />
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-    </encoder>
-  </appender>
+<!--  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">-->
+<!--    <encoder>-->
+<!--      <pattern>${CONSOLE_LOG_PATTERN}</pattern>-->
+<!--    </encoder>-->
+<!--  </appender>-->
 
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -7,8 +7,6 @@
   The console log pattern has been modified from the default to include request ID and user ID if present
   -->
   <property name="CONSOLE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%15.15t] %-40.40logger{39} : %replace(%mdc - %msg){'  - ',' '}%n%ex" />
-  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/AN-1, https://broadworkbench.atlassian.net/browse/AN-212

**jre:17-12-distroless** - I am following Data Catalog team's principle of trying to make the least changes in base image possible so that it doesn't break anything in CBAS (instead of upgrading to JRE 21). [This PR](https://github.com/DataBiosphere/terra-data-catalog/pull/177#issue-2573613554) has a good description on what and why. [This Slack thread](https://broadinstitute.slack.com/archives/C0DSD41QT/p1728328182615109) also has details on why jre:17 debain 12 image was created.

**spring-web** dependency fix -
Before upgrade
```
service % ../gradlew dependencyInsight --dependency org.springframework:spring-web

> Task :service:dependencyInsight
org.springframework:spring-web:6.1.4 (selected by rule)

org.springframework:spring-web:6.1.4
+--- org.springframework:spring-webmvc:6.1.4
|    \--- org.springframework.boot:spring-boot-starter-web:3.2.3
|         \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
+--- org.springframework.boot:spring-boot-starter-json:3.2.3
|    +--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)
|    \--- bio.terra:externalcreds-client-resttemplate:1.31.0-SNAPSHOT:20240418.183148-1
|         \--- compileClasspath
\--- org.springframework.boot:spring-boot-starter-web:3.2.3 (*)

org.springframework:spring-webmvc:6.1.4 (selected by rule)

org.springframework:spring-webmvc:6.1.4
\--- org.springframework.boot:spring-boot-starter-web:3.2.3
     \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
```

After upgrade
```
 service % ../gradlew dependencyInsight --dependency org.springframework:spring-web

> Task :service:dependencyInsight
org.springframework:spring-web:6.1.14 (selected by rule)

org.springframework:spring-web:6.1.14
+--- org.springframework:spring-webmvc:6.1.14
|    \--- org.springframework.boot:spring-boot-starter-web:3.3.5
|         \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
+--- org.springframework.boot:spring-boot-starter-json:3.3.5
|    +--- org.springframework.boot:spring-boot-starter-web:3.3.5 (*)
|    \--- bio.terra:externalcreds-client-resttemplate:1.31.0-SNAPSHOT:20240418.183148-1 (requested org.springframework.boot:spring-boot-starter-json:3.2.3)
|         \--- compileClasspath
\--- org.springframework.boot:spring-boot-starter-web:3.3.5 (*)

org.springframework:spring-webmvc:6.1.14 (selected by rule)

org.springframework:spring-webmvc:6.1.14
\--- org.springframework.boot:spring-boot-starter-web:3.3.5
     \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
```

**Testing**: I published a test image containing the changes and manually upgraded Workflows app in Dev workspace, imported methods and ran workflows. Things were working as expected.

https://github.com/DataBiosphere/terra-data-catalog/pull/177